### PR TITLE
Added capability to specify agent branch when installing

### DIFF
--- a/install_agent_from_github.sh
+++ b/install_agent_from_github.sh
@@ -32,7 +32,14 @@ fi
 echo -e "${BLUE}[*]${NC} Making 'temp' folder"
 mkdir temp
 echo -e "${BLUE}[*]${NC} Pulling down remote repo via git"
-git clone --recurse-submodules --single-branch $1 temp
+if [ $# -eq 2 ]
+then
+        echo "Installing From Branch: $2"
+        git clone --recurse-submodules --single-branch --branch $2 $1 temp
+else
+        echo "Installing From master"
+        git clone --recurse-submodules --single-branch $1 temp
+fi
 if [ $? -ne 0 ]
 then
   echo -e "${RED}[-]${NC} Failed to pull down remote repo. Aborting"

--- a/install_agent_from_github.sh
+++ b/install_agent_from_github.sh
@@ -34,10 +34,10 @@ mkdir temp
 echo -e "${BLUE}[*]${NC} Pulling down remote repo via git"
 if [ $# -eq 2 ]
 then
-        echo "Installing From Branch: $2"
+        echo -e "${BLUE}[*]${NC} Installing From Branch: $2"
         git clone --recurse-submodules --single-branch --branch $2 $1 temp
 else
-        echo "Installing From master"
+        echo -e "${BLUE}[*]${NC} Installing From master"
         git clone --recurse-submodules --single-branch $1 temp
 fi
 if [ $? -ne 0 ]


### PR DESCRIPTION
I made a QOL change to `install_agent_from_github.sh` when doing bugfixing for Apollo that allows for specifying a branch when installing an agent from github. 

Syntax:
`./install_agent_from_github.sh github_url [branch_name]`

If no branch is provided, it will clone from master like how it currently works.