### PR TITLE
Remove await keyword from HTTP response

### DIFF
--- a/Example_C2_Profile/c2_code/server
+++ b/Example_C2_Profile/c2_code/server
@@ -19,7 +19,7 @@ async def print_flush(message):
 
 
 async def server_error_handler(request, exception):
-    return await html("Error: Requested URL {} not found".format(request.url), status=404, headers=config[request.app.name]['headers'])
+    return html("Error: Requested URL {} not found".format(request.url), status=404, headers=config[request.app.name]['headers'])
 
 
 async def agent_message(request, **kwargs):


### PR DESCRIPTION
Fixes a minor bug with the example code. Sanic throws an exception when using `await` with a `http` response.