### PR TITLE
Added verbosity to the comment on wrapped_payloads

### DIFF
--- a/Example_Payload_Type/mythic/agent_functions/builder.py
+++ b/Example_Payload_Type/mythic/agent_functions/builder.py
@@ -12,7 +12,7 @@ class Atlas(PayloadType):
     author = "@Airzero24"  # author of the payload type
     supported_os = [SupportedOS.Windows]  # supported OS and architecture combos
     wrapper = False  # does this payload type act as a wrapper for another payloads inside of it?
-    wrapped_payloads = []  # if so, which payload types
+    wrapped_payloads = []  # if so, which payload types. If you are writing a wrapper, you will need to modify this variable (adding in your wrapper's name) in the builder.py of each payload that you want to utilize your wrapper.
     note = """Any note you want to show up about your payload type in the UI"""
     supports_dynamic_loading = False  # setting this to True allows users to only select a subset of commands when generating a payload
     build_parameters = {


### PR DESCRIPTION
Clarified that, when writing a wrapper, devs need to modify the `wrapped_payloads` variable to include the name of the new wrapper within the builder.py of each payload that they want to be able to utilize.

This is a pretty trivial change, but it caught me for a bit while writing a wrapper.