### PR TITLE
Fixing missing spaces in process command line arguments in Poseidon

### DIFF
--- a/Payload_Types/poseidon/agent_code/ps/ps_linux.go
+++ b/Payload_Types/poseidon/agent_code/ps/ps_linux.go
@@ -84,7 +84,8 @@ func (p *UnixProcess) BundleID() string {
 func getProcessCmdline(pid int) string {
 	filename := fmt.Sprintf("/proc/%d/cmdline", pid)
 	f, _ := ioutil.ReadFile(filename)
-	return string(f)
+	p := strings.ReplaceAll(string(f), "\x00", " ")
+	return p
 }
 func getProcessOwner(pid int) (string, error) {
 	filename := fmt.Sprintf("/proc/%d/task", pid)


### PR DESCRIPTION
The process command line file is delimited with NULL characters. This PR replaces these characters with spaces to make the output os the `ps` command on Linux more readable.