### PR TITLE
Added SSLv3 extensions to certificate

### DIFF
--- a/start_mythic.sh
+++ b/start_mythic.sh
@@ -39,7 +39,7 @@ fi
 
 if [ ! -f "./mythic-docker/app/ssl/mythic-ssl.key" ]; then
    echo -e "${BLUE}[*]${NC} Failed to find ssl keys, generating new ones"
-   openssl req -new -x509 -keyout ./mythic-docker/app/ssl/mythic-ssl.key -out ./mythic-docker/app/ssl/mythic-cert.pem -days 365 -nodes -subj "/C=US" >/dev/null 2>&1
+   openssl req -new -x509 -keyout ./mythic-docker/app/ssl/mythic-ssl.key -out ./mythic-docker/app/ssl/mythic-cert.pem -days 365 -extensions v3_req -nodes -subj "/C=US" >/dev/null 2>&1
    echo -e "${GREEN}[+]${NC} Generated new SSL self signed certificates"
 fi
 server_port=`jq ".listen_port" "mythic-docker/config.json"`


### PR DESCRIPTION
In order to fix browser certificate errors the "v3_req" extensions flag was added to the _openssl_ command in the start script