### PR TITLE
Fix mythic.py for use with existing API tokens

### DIFF
--- a/Mythic_CLI/mythic.py
+++ b/Mythic_CLI/mythic.py
@@ -3351,7 +3351,6 @@ class Mythic:
             self._apitoken = apitoken
         else:
             self._apitoken = APIToken(token_value=apitoken)
-        self._apitoken = apitoken
         self._access_token = access_token
         self._refresh_token = refresh_token
         self._server_ip = server_ip


### PR DESCRIPTION
When you use the Mythic API wrapper with a token instead of a username and password, this duplicate call `self._apitoken = apitoken` overwrites `self._apitoken` with the plain string value of your token—clobbering the instance of `APIToken` that was just set on the line before it.

Later on when that value is used, the SDK will complain that the string doesn't have a `token_value` attribute:

    AttributeError: 'str' object has no attribute 'token_value'