### PR TITLE
Add non interactive run capability to start_mythic script

### DIFF
--- a/start_mythic.sh
+++ b/start_mythic.sh
@@ -1,4 +1,8 @@
 #! /bin/bash
+
+# Set working directory for unattended starts
+cd "${0%/*}"
+
 RED='\033[1;31m'
 NC='\033[0m' # No Color
 GREEN='\033[1;32m'


### PR DESCRIPTION
Running start_mythic.sh non interactively via user data in AWS or on boot with cron/service/etc breaks on the relative paths of the script. Line 4 of the script sets the working directory for execution to the parent of the script (top level Mythic directory by default) to correct for that behavior.