### PR TITLE
Updated authentication mechanism

### DIFF
--- a/mythic-docker/app/routes/routes.py
+++ b/mythic-docker/app/routes/routes.py
@@ -180,7 +180,7 @@ class Login(BaseEndpoint):
                     form.username.errors = ["Username or password invalid"]
             except Exception as e:
                 print(str(sys.exc_info()[-1].tb_lineno) + " " + str(e))
-                form.username.errors = ["username or password invalid"]
+                form.username.errors = ["Username or password invalid"]
         errors["username_errors"] = "<br>".join(form.username.errors)
         errors["password_errors"] = "<br>".join(form.password.errors)
         template = env.get_template("login.html")


### PR DESCRIPTION
The string "Username or password invalid" was different when a user authentication failed with an existing user and an non-existent user.

Modified the string so they are now the same.