### PR TITLE
Poseidon hardcoded proxy settings fix

### DIFF
--- a/Payload_Types/poseidon/agent_code/c2_profiles/HTTP.go
+++ b/Payload_Types/poseidon/agent_code/c2_profiles/HTTP.go
@@ -106,13 +106,13 @@ func (c *C2Default) CheckIn(ip string, pid int, user string, host string, operat
 	c.QueryPathName = Config.QueryPathName
 
 	// Add proxy info if set
-	if len(Config.ProxyURL) > 0 && !strings.Contains(Config.ProxyURL, "proxy_host:proxy_port/") {
+	if len(Config.ProxyURL) > 0 && !strings.Contains(Config.ProxyURL, "proxy" + "_host:proxy" + "_port/") {
 		c.ProxyURL = Config.ProxyURL
 	} else {
 		c.ProxyURL = ""
 	}
 
-	if !strings.Contains(Config.ProxyUser, "proxy_user") && !strings.Contains(Config.ProxyPass, "proxy_pass") {
+	if !strings.Contains(Config.ProxyUser, "proxy" + "_user") && !strings.Contains(Config.ProxyPass, "proxy" + "_pass") {
 		if len(Config.ProxyUser) > 0 && len(Config.ProxyPass) > 0 {
 			c.ProxyUser = Config.ProxyUser
 			c.ProxyPass = Config.ProxyPass


### PR DESCRIPTION
Fixing Poseidon hardcoded proxy config bug.

While Mythic UI allows to specify proxy settings for the Poseidon implant, these settings are not actually being followed by the implant itself (e.g.: you can specify the proxy settings but the implant will still talk to the C2 directly instead of going through the proxy).

The reason for this issue is that during the implant building process, `proxy_host`, `proxy_port`, `proxy_user` and `proxy_pass` strings in the `HTTP.go` document are being replaced by the operator-provided proxy settings. 

However, the implant `CheckIn` function also use the strings `proxy_host:proxy_port/`, `proxy_user` and `proxy_pass` in comparison operations to determine if the proxy settings have been provided by the operator. Since the strings used in comparison match the strings that are being overwritten with the proxy configuration, both are being overwritten with the same data which compromises the comparison logic. The comparison always returns `True` no matter if the proxy settings were provided or not.

The simple fix above breaks the strings into several substrings in order to preserver the comparison logic and avoid being overwritten by the builder script at the same time.