### PR TITLE
Split choices to properly display in dropdown

### DIFF
--- a/mythic-docker/app/templates/split_callback.js
+++ b/mythic-docker/app/templates/split_callback.js
@@ -179,6 +179,7 @@ var callback_table = new Vue({
                                         continue;
                                     }
                                     if(param.choices.length > 0){
+                                        param.choices = param.choices.split("\n");
                                         param.choice_value = param.choices[0];
                                         param.choicemultiple_value = [param.choices[0]];
                                     }


### PR DESCRIPTION
![curl](https://user-images.githubusercontent.com/16919262/140154873-3ebcb3f5-730f-4031-acc2-885dff4fe0c8.png)

I noticed that some agents use *ParameterType.ChooseOne*.  For example, Poseidon's *curl* command uses this for the *method* parameter passing along a list of `["GET","POST"]`. However, *split_callback.js* doesn't properly split on the newline so the result is that the drop-down presented has the individual letters.  If you submit, the curl command then sends with method *G* instead of *GET* causing a 405 error on the server that gets this request.

Being new to the project and web frameworks, I'm not 100% sure if this is the right place for this fix or if there are additional places that need adjusting.  However, with these updates, this displayed properly and more importantly, the command executed successfully.  I also understand that you are updating the interface to a newer framework that may or may not have the same issues.