### PR TITLE
Ensure ParameterType.Boolean ends back up as a boolean rather than a string.

### DIFF
--- a/mythic-docker/app/templates/split_callback.js
+++ b/mythic-docker/app/templates/split_callback.js
@@ -259,7 +259,13 @@ var callback_table = new Vue({
                                         // if this is the first time the parameter is created, it'll error out which is expected
                                     }
                                 }else if(param.type === "Boolean"){
-                                    param.boolean_value = param.default_value;
+                                    if (param.boolean_value === "False") {
+                                        param.boolean_value = false;
+                                    } else if (param.boolean_value === "True") {
+                                        param.boolean_value = true;
+                                    } else {
+                                        param.boolean_value = param.default_value;
+                                    }
                                 }
                                 if (param.type === 'PayloadList') {
                                     // we only want to add to param.payloads things from params_table.payloads that match the supported_agent types listed


### PR DESCRIPTION
In working with *Apollo* and *Poseidon* I noticed that some modules that used *ParameterType.Boolean* were failing as soon as I submitted them.  When I looked at the output, the failure indicated a value was not a bool:

![upload4](https://user-images.githubusercontent.com/16919262/140164035-ff1a200e-d533-4438-ab6a-64a31ab1028b.png)

This comes from the *validateBoolean* function inside of *MythicCommandBase.py*.  Looking further into this, I noticed that the parameter was getting copied into  *boolean_value" as a string rather than a bool in the javascript:

![upload1](https://user-images.githubusercontent.com/16919262/140164538-01181816-7a1d-4989-bda3-a182bbca0a24.png)

That string eventually ends up in the *load_args_from_json_string* function when being parsed.  When I output the values, I can see that the value gets passed along as a string and not a boolean.  The below image is a before and after shot of the proposed adjustments:

![upload3](https://user-images.githubusercontent.com/16919262/140165397-9696abac-8ff8-44ee-8a67-17c5918733b3.png)

The same effect happens for the *Apollo blockdll* command.

Lastly, I'm new with this project and web-frameworks in general.  I'm not 100% sure this is the right place to fix this as it seems more like a hack than anything else.  However, making this adjustment fixed the two mentioned commands for me.
