### PR TITLE
QoL fix to command autocomplete functionality

### DIFF
--- a/mythic-docker/app/templates/callbacks.js
+++ b/mythic-docker/app/templates/callbacks.js
@@ -4161,6 +4161,11 @@ function autocomplete(inp, arr) {
                 meta[task_data.input_field_placeholder['cid']]["commands"][i]["attributes"]["supported_os"].includes(callbacks[task_data.input_field_placeholder['cid']]["payload_os"])
         )
             ) {
+            	/*exit autocomplete if text fully matches command*/
+            	if (meta[task_data.input_field_placeholder['cid']]["commands"][i]["name"].toUpperCase() === val.toUpperCase())
+            	{
+                	closeAllLists();
+            	}
                 /*create a DIV element for each matching element:*/
                 if (meta[task_data.input_field_placeholder['cid']]["commands"][i]["name"].length > longest) {
                     longest = meta[task_data.input_field_placeholder['cid']]["commands"][i]["name"].length;


### PR DESCRIPTION
Currently when entering commands that do not take any additional arguments, the autocomplete command window forces the user to hit enter twice to execute the command. In addition, when using the popular Apollo agent, typing "ls" shows the autocomplete command window having "ls" and "blockdlls" with the latter being the default selected. This results in accidental execution of "blockdlls" when trying to just quickly "ls".

The small fix I have implemented to address both issues simply closes the autocomplete window when the current text input exactly matches a command in the command list.
