### PR TITLE
fix #132 missing username key

### DIFF
--- a/mythic-docker/app/templates/operations_management.js
+++ b/mythic-docker/app/templates/operations_management.js
@@ -138,7 +138,7 @@ var operations_table = new Vue({
                     for (let i = 0; i < operators_vue.operation_members.length; i++) {
                         if (operators_vue.operation_members[i]['selected']) {
                             data['members'].push({
-                                "username": operators_vue.operation_members[i]['name'],
+                                "username": operators_vue.operation_members[i]['username'],
                                 "view_mode": operators_vue.operation_members[i]['view_mode']
                             });
                         }


### PR DESCRIPTION
I can confirm that after this change, operations can now created normally with members.