### PR TITLE
Warn if a request is blocked due to ALLOWED_IPS

### DIFF
--- a/mythic-docker/app/routes/routes.py
+++ b/mythic-docker/app/routes/routes.py
@@ -360,6 +360,7 @@ async def check_ips(request):
         for block in mythic.config["ALLOWED_IPS"]:
             if ip in block:
                 return
+        logger.warning(f"Rejecting request to {request.path} from {ip} based on ALLOWED_IPS")
         return json({"error": "Not Found"}, status=404)
 
 """


### PR DESCRIPTION
This took some time to debug and figure out why I got a 404 response when I was experimenting with putting another front-end proxy in front of Mythic :-).