### PR TITLE
Added dockercompose version number to yaml generation

### DIFF
--- a/Mythic_CLI/src/cmd/internal/dockercompose.go
+++ b/Mythic_CLI/src/cmd/internal/dockercompose.go
@@ -761,6 +761,7 @@ func RemoveDockerComposeEntry(service string) error {
 			"com.docker.network.bridge.name": "mythic_if",
 		})
 	}
+	curConfig.Set("version","2.4")
 	curConfig.WriteConfig()
 	return nil
 }


### PR DESCRIPTION
Error was occurring on new builds where I was getting:

"The Compose file './docker-compose.yml' is invalid because: Unsupported config option for networks: 'default_network' Unsupported config option for services: 'mythic_nginx' "
With no version specified, it defaults to version 1, which doesn't like some of the newer options that was being written out.