### PR TITLE
fix index out of range error on agent/c2 install

### DIFF
--- a/Mythic_CLI/src/cmd/installGitHub.go
+++ b/Mythic_CLI/src/cmd/installGitHub.go
@@ -27,7 +27,12 @@ func init() {
 }
 
 func installGitHub(cmd *cobra.Command, args []string) {
-	if err := internal.InstallService(args[0], args[1], force); err != nil {
+	var branch = ""
+	
+	if len(args) == 2 {
+		branch = args[1]
+	}
+	if err := internal.InstallService(args[0], branch, force); err != nil {
 		fmt.Printf("[-] Failed to install service: %v\n", err)
 	} else {
 		fmt.Printf("[+] Successfully installed service!")


### PR DESCRIPTION
If the (non-required) branch was not specified when installing from GitHub, the args[1] value would not exist, throwing an exception. Maybe there is a better way to check argument values (or just set a default of "") with the cobra cli library.