### PR TITLE
Fix shorthand notation for the '-f' flag when installing components through the mythic-cli

### DIFF
--- a/Mythic_CLI/src/cmd/installFolder.go
+++ b/Mythic_CLI/src/cmd/installFolder.go
@@ -17,8 +17,9 @@ var installFolderCmd = &cobra.Command{
 
 func init() {
 	installCmd.AddCommand(installFolderCmd)
-	installFolderCmd.Flags().BoolVar(
+	installFolderCmd.Flags().BoolVarP(
 		&force,
+		"force",
 		"f",
 		false,
 		`Force installing from local folder and don't prompt to overwrite files if an older version is already installed'`,

--- a/Mythic_CLI/src/cmd/installGitHub.go
+++ b/Mythic_CLI/src/cmd/installGitHub.go
@@ -18,8 +18,9 @@ var force bool
 
 func init() {
 	installCmd.AddCommand(installGitHubCmd)
-	installGitHubCmd.Flags().BoolVar(
+	installGitHubCmd.Flags().BoolVarP(
 		&force,
+		"force",
 		"f",
 		false,
 		`Force installing from GitHub and don't prompt to overwrite files if an older version is already installed'`,


### PR DESCRIPTION
When installing agents/profiles through the mythic-cli, the `f` flag needs to include two dashes `--f`.

The current way to do a force install using the shorthand force flag with the mythic-cli is `./mythic-cli install github [agent url] --f`. Cobra is treating the `f` command line flag as the long form version which results in needing two dashes for the shorthand version of the flag.

```bash
[root@mythic Mythic]# ./mythic-cli install github --help
Run this command to install services from Git-based repositories by doing a git clone

Usage:
  mythic-cli install github url [branch] [-f] [flags]

Flags:
      --f      Force installing from GitHub and don't prompt to overwrite files if an older version is already installed'
  -h, --help   help for github
[root@mythic Mythic]#
```

This PR will make the force flag follow more standard conventions.

```bash
[root@mythic Mythic]# ./mythic-cli install github --help
Run this command to install services from Git-based repositories by doing a git clone

Usage:
  mythic-cli install github url [branch] [-f] [flags]

Flags:
  -f, --force   Force installing from GitHub and don't prompt to overwrite files if an older version is already installed'
  -h, --help    help for github
[root@mythic Mythic]#
```