### PR TITLE
Propagate Filename field to payload builder

### DIFF
--- a/mythic-docker/src/rabbitmq/send_pt_payload_build.go
+++ b/mythic-docker/src/rabbitmq/send_pt_payload_build.go
@@ -166,6 +166,7 @@ func RegisterNewPayload(payloadDefinition PayloadConfiguration, operatorOperatio
 					OperationID:     operatorOperation.CurrentOperation.ID,
 					OperatorID:      operatorOperation.CurrentOperator.ID,
 					PayloadFileUUID: fileMeta.AgentFileID,
+					Filename:        payloadDefinition.Filename,
 				}
 				SendPayloadBuildMessage(databasePayload, rabbitmqPayloadBuildMsg)
 				return databasePayload.UuID, databasePayload.ID, nil


### PR DESCRIPTION
When Mythic kicks off a payload build, it will never add the Filename field to the payload build message when passing the data to the payload build container. This results in the `Filename` field of the `PayloadBuildMessage` always containing an empty string when being referenced in the build function of the agent. https://github.com/MythicMeta/MythicContainer/blob/main/agent_structs/structs_payload_build.go#L17

This commit adds the file name to the payload build information before sending it over rabbitmq to the payload container.