### PR TITLE
Refactor authentication

### DIFF
--- a/mythic-docker/src/authentication/jwt.go
+++ b/mythic-docker/src/authentication/jwt.go
@@ -28,6 +28,7 @@ var (
 	AUTH_METHOD_USER  = "user"
 	AUTH_METHOD_API   = "api"
 )
+
 var (
 	ErrUnexpectedSigningMethod         = errors.New("Unexpected signing method")
 	ErrGetApiTokenOrBearer             = errors.New("Failed to get apitoken or bearer token")

--- a/mythic-docker/src/authentication/jwt_test.go
+++ b/mythic-docker/src/authentication/jwt_test.go
@@ -1,0 +1,150 @@
+package authentication
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt"
+	databaseStructs "github.com/its-a-feature/Mythic/database/structs"
+)
+
+func TestTokenValid(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		header map[string][]string
+	}
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	user := databaseStructs.Operator{ID: 123}
+	access_token, _, _, _ := GenerateJWT(user, AUTH_METHOD_USER)
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Missing Auth Header",
+			args: args{
+				header: map[string][]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Valid token",
+			args: args{
+				header: map[string][]string{
+					"Authorization": {"Bearer " + access_token},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid bearer",
+			args: args{
+				header: map[string][]string{
+					"Authorization": {"Bearer invalid bearer"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Bearer too short",
+			args: args{
+				header: map[string][]string{
+					"Authorization": {"Bearer tooshort"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // shadowing
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := &http.Request{
+				Header: make(http.Header),
+			}
+			req.Header = tt.args.header
+			c.Request = req
+			// engine.Header["Authorization"] = tt.args.authHeader
+			if err := TokenValid(c); (err != nil) != tt.wantErr {
+				t.Errorf("TokenValid() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetClaims(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		header map[string][]string
+	}
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	user := databaseStructs.Operator{ID: 123}
+	access_token, _, _, _ := GenerateJWT(user, AUTH_METHOD_USER)
+
+	tests := []struct {
+		name    string
+		args    args
+		want    *CustomClaims
+		wantErr bool
+	}{
+		{
+			name: "Valid Claim",
+			args: args{
+				header: map[string][]string{
+					"Authorization": {"Bearer " + access_token},
+				},
+			},
+			want: &CustomClaims{
+				UserID:     123,
+				AuthMethod: AUTH_METHOD_USER,
+				StandardClaims: jwt.StandardClaims{
+					IssuedAt:  time.Now().Unix(),
+					ExpiresAt: time.Now().Add(JWTTimespan).UTC().Unix(),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Bad claim format",
+			args: args{
+				header: map[string][]string{
+					"Authorization": {"Bearer " + "invalid_preffix" + access_token},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // shadowing
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := &http.Request{
+				Header: make(http.Header),
+			}
+			req.Header = tt.args.header
+			c.Request = req
+			got, err := GetClaims(c)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetClaims() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetClaims() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/mythic-docker/src/authentication/jwt_test.go
+++ b/mythic-docker/src/authentication/jwt_test.go
@@ -100,7 +100,7 @@ func TestGetClaims(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Valid Claim",
+			name: "Valid bearer Claim",
 			args: args{
 				header: map[string][]string{
 					"Authorization": {"Bearer " + access_token},
@@ -117,10 +117,37 @@ func TestGetClaims(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Bad claim format",
+			name: "Bad bearer claim format",
 			args: args{
 				header: map[string][]string{
 					"Authorization": {"Bearer " + "invalid_preffix" + access_token},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Valid apitoken Claim",
+			args: args{
+				header: map[string][]string{
+					"Apitoken": {access_token}, // Apitoken and not apitoken here because Go uses the canonical form (first letter of the word and after hyphens as uppercase)
+				},
+			},
+			want: &CustomClaims{
+				UserID:     123,
+				AuthMethod: AUTH_METHOD_USER,
+				StandardClaims: jwt.StandardClaims{
+					IssuedAt:  time.Now().Unix(),
+					ExpiresAt: time.Now().Add(JWTTimespan).UTC().Unix(),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Empty apitoken",
+			args: args{
+				header: map[string][]string{
+					"Apitoken": {""},
 				},
 			},
 			want:    nil,
@@ -131,7 +158,7 @@ func TestGetClaims(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt // shadowing
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 			req := &http.Request{
 				Header: make(http.Header),
 			}


### PR DESCRIPTION
Follow up of this https://github.com/its-a-feature/Mythic/issues/286, happy to discuss.

This PR adds:
- exports errors (so we can use errors.Is() in other package)
- Add tests
- Extracts SQL Queries

Notes:
The line `token := c.Request.Header.Get("apitoken")` is IMO missleading: the actual header is "Apitoken" because it's canonical-ified, and thus is equal to `token := c.Request.Header.Get("Apitoken")`  (note the capital A)
What do you think about updating it to the last one to match what's the user is supposed to provide? (`Apitoken` and not `apitoken`)