### PR TITLE
Run `build_all_macos` from `make macos`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ linux:
 	cd Mythic_CLI && make && mv mythic-cli ../
 
 macos:
-	cd Mythic_CLI && make build_binary_macos && mv mythic-cli ../
+	cd Mythic_CLI && make build_all_macos && mv mythic-cli ../
 
 macos_local:
 	cd Mythic_CLI && make build_binary_macos_local


### PR DESCRIPTION
Ensures the `mythic-cli` image is built locally before trying to use it to build the CLI on macOS