### PR TITLE
Make install_docker scripts architecture independent

### DIFF
--- a/install_docker_debian.sh
+++ b/install_docker_debian.sh
@@ -6,6 +6,6 @@ fi
 
 apt install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
 curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-add-apt-repository -y "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+add-apt-repository -y "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
 apt update
 apt-get install -y --no-install-recommends docker-ce docker-compose-plugin

--- a/install_docker_ubuntu.sh
+++ b/install_docker_ubuntu.sh
@@ -15,7 +15,7 @@ apt-get install -y \
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 
 add-apt-repository -y \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu \
    $(lsb_release -cs) \
    stable"
 


### PR DESCRIPTION
Updates the install-docker scripts so that it checks the system architecture, as per the [Docker install instructions](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) so that it will correctly install e.g. on a VM on Apple Silicon.