### PR TITLE
Prevent root-owned files ending up on the filesystem during CLI build

### DIFF
--- a/Mythic_CLI/Makefile
+++ b/Mythic_CLI/Makefile
@@ -1,4 +1,3 @@
-BINARY_NAME=mythic-cli
 LOCAL_PATH=$(shell pwd)
 BUILDER_IMAGE=ghcr.io/its-a-feature/mythic_cli:v3.3.0.14
 .PHONY: default
@@ -11,25 +10,33 @@ default: build_linux ;
 export
 
 copy_binary_linux:
-	docker run -v ${LOCAL_PATH}/copy_file/:/copy_file/ --rm ${BUILDER_IMAGE} sh -c "cp /mythic-cli_linux /copy_file/mythic-cli"
-	mv ./copy_file/${BINARY_NAME} . && rm -rf ./copy_file && chmod +x ${BINARY_NAME}
+	docker create --name mythic-cli-tmp ${BUILDER_IMAGE} /bin/sh
+	docker cp mythic-cli-tmp:/mythic-cli_linux ./${BINARY_NAME}
+	docker rm mythic-cli-tmp
+	chmod +x ${BINARY_NAME}
 
 copy_binary_macos:
-	docker run -v ${LOCAL_PATH}/copy_file/:/copy_file/ --rm ${BUILDER_IMAGE} sh -c "cp /mythic-cli_macos /copy_file/mythic-cli"
-	mv ./copy_file/${BINARY_NAME} . && rm -rf ./copy_file && chmod +x ${BINARY_NAME}
+	docker create --name mythic-cli-tmp ${BUILDER_IMAGE} /bin/sh
+	docker cp mythic-cli-tmp:/mythic-cli_macos ./${BINARY_NAME}
+	docker rm mythic-cli-tmp
+	chmod +x ${BINARY_NAME}
 
 build_local:
 	cd src && go build -o ../../mythic-cli .
 
 build_linux_docker:
 	docker build -t mythic-cli-builder -f Dockerfile .
-	docker run -v ${LOCAL_PATH}/copy_file/:/copy_file/ --rm mythic-cli-builder sh -c "cp /mythic-cli_linux /copy_file/mythic-cli"
-	mv ./copy_file/${BINARY_NAME} . && rm -rf ./copy_file && chmod +x ${BINARY_NAME}
+	docker create --name mythic-cli-tmp mythic-cli-builder /bin/sh
+	docker cp mythic-cli-tmp:/mythic-cli_linux ./${BINARY_NAME}
+	docker rm mythic-cli-tmp
+	chmod +x ${BINARY_NAME}
 
 build_macos_docker:
 	docker build -t mythic-cli-builder -f Dockerfile .
-	docker run -v ${LOCAL_PATH}/copy_file/:/copy_file/ --rm mythic-cli-builder sh -c "cp /mythic-cli_macos /copy_file/mythic-cli"
-	mv ./copy_file/${BINARY_NAME} . && rm -rf ./copy_file && chmod +x ${BINARY_NAME}
+	docker create --name mythic-cli-tmp mythic-cli-builder /bin/sh
+	docker cp mythic-cli-tmp:/mythic-cli_macos ./${BINARY_NAME}
+	docker rm mythic-cli-tmp
+	chmod +x ${BINARY_NAME}
 
 build_linux: copy_binary_linux
 build_macos: copy_binary_macos

--- a/Mythic_CLI/Makefile
+++ b/Mythic_CLI/Makefile
@@ -1,3 +1,4 @@
+BINARY_NAME=mythic-cli
 LOCAL_PATH=$(shell pwd)
 BUILDER_IMAGE=ghcr.io/its-a-feature/mythic_cli:v3.3.0.14
 .PHONY: default


### PR DESCRIPTION
Using `docker cp` means that when you copy the CLI binary out of the filesystem, it ends up owned by the user running the build, rather than root.