### PR TITLE
allow wrappers to specify payloads it can wrap

### DIFF
--- a/mythic-docker/src/database/schema.go
+++ b/mythic-docker/src/database/schema.go
@@ -4847,6 +4847,13 @@ ALTER TABLE ONLY public.wrappedpayloadtypes
 ALTER TABLE ONLY public.wrappedpayloadtypes
     ADD CONSTRAINT wrappedpayloadtypes_wrapper_id_fkey FOREIGN KEY (wrapper_id) REFERENCES public.payloadtype(id) ON DELETE CASCADE;
 
+--
+-- Name: wrappedpayloadtypes wrappedpayloadtypes_wrapper_id_wrapped_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wrappedpayloadtypes
+    ADD CONSTRAINT wrappedpayloadtypes_wrapper_id_wrapped_id_key UNIQUE (wrapper_id, wrapped_id);
+
 CREATE EXTENSION pg_stat_statements SCHEMA public;
 
 --


### PR DESCRIPTION
As discussed in https://github.com/its-a-feature/Mythic/discussions/426 I implemented the code which allows to specify payload-to-wrapper relationship on both payload and wrapper sides. I decided to reuse `wrapped_payloads` field for wrapper payloads to avoid message structure changes. The code making the relationships is probably not DRY, but more readable.

I also added UNIQUE CONSTRAINT to `wrappedpayloadtypes` which is not necessary as long as we have only single AMQP consumer, but I still think it is a good guarantee of data consistency without any reasonable overhead