### PR TITLE
Fix Docker installation scripts

### DIFF
--- a/install_docker_debian.sh
+++ b/install_docker_debian.sh
@@ -5,7 +5,10 @@ if [ "$EUID" -ne 0 ]
 fi
 
 apt install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
-curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-add-apt-repository -y "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/debian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 apt update
 apt-get install -y --no-install-recommends docker-ce docker-compose-plugin

--- a/install_docker_kali.sh
+++ b/install_docker_kali.sh
@@ -10,8 +10,11 @@ apt update
 # Install Docker and Docker Compose
 #apt install docker.io docker-compose -y
 apt install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
-curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-add-apt-repository -y "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/debian bookworm stable"
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list
 apt update
 apt-get install -y --no-install-recommends docker-ce docker-compose-plugin
 # apt-get install -y --no-install-recommends docker-ce docker-ce-cli containerd.io

--- a/install_docker_ubuntu.sh
+++ b/install_docker_ubuntu.sh
@@ -12,12 +12,15 @@ apt-get install -y \
     gnupg-agent \
     software-properties-common
 
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
 
-add-apt-repository -y \
-   "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu \
+echo \
+   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+   https://download.docker.com/linux/ubuntu \
    $(lsb_release -cs) \
-   stable"
+   stable" > /etc/apt/sources.list.d/docker.list
 
 apt-get update
 


### PR DESCRIPTION
Hi.
apt-key is deprecated and already removed on kali so I replaced it with the new flow of downloading the key and referencing it within the sourceline.