### PR TITLE
add missing space to help description

### DIFF
--- a/mythic-docker/src/rabbitmq/util_create_task.go
+++ b/mythic-docker/src/rabbitmq/util_create_task.go
@@ -796,7 +796,7 @@ func handleHelpCommand(createTaskInput CreateTaskInput, callback databaseStructs
 		fmt.Fprintln(w, "=======\t============")
 		for _, row := range outputFields {
 			fmt.Fprintln(w, row[0]+"\tUsage: "+row[1])
-			fmt.Fprintln(w, "\tDescription:"+strings.ReplaceAll(row[2], "\n", ""))
+			fmt.Fprintln(w, "\tDescription: "+strings.ReplaceAll(row[2], "\n", ""))
 		}
 		w.Flush()
 		go updateTaskStatus(task.ID, "completed", true)


### PR DESCRIPTION
the `Description` field returned from tasks currently is missing a space. just a quick fix :)

```
help     Usage: help [command]
         Description:The 'help' command gives detailed information about specific commands or general information about all available commands.
```