### PR TITLE
Fix OperationID always being 0 in emitTaskLog

### DIFF
--- a/mythic-docker/src/rabbitmq/utils_siem_message_create_and_emit.go
+++ b/mythic-docker/src/rabbitmq/utils_siem_message_create_and_emit.go
@@ -10,6 +10,7 @@ import (
 func emitTaskLog(taskId int) {
 	task := databaseStructs.Task{}
 	if err := database.DB.Get(&task, `SELECT
+    task.*,
     operation.name "operation.name",
     operator.username "operator.username"
     FROM task


### PR DESCRIPTION
## Description

While working on the RedELK logger for Mythic, I noticed that for `new_task` events, `operation_id` is always set 0, regardless of which operation the task was created in.

## Cause

`task.*` was not included in the `emitTaskLog`'s SELECT statement, resulting in `task.OperationID` seemingly defaulting to 0. `emitTaskLog` was the only one not following the pattern (for example, `emitPayloadLog` properly include `payload.*` in it's own SELECT), and the only one that appears to have been bugged.

## Tested

Yes. Tested by applying the fix and setting `MYTHIC_SERVER_USE_BUILD_CONTEXT` to `true` and rebuilding it. After, I submitted new tasks to an agent (same agent as before the fix was applied), and the correct operation_id is now reflected.