### PR TITLE
Pass JUPYTER_PORT into mythic_jupyter container

### DIFF
--- a/Mythic_CLI/src/cmd/internal/serviceMetadata.go
+++ b/Mythic_CLI/src/cmd/internal/serviceMetadata.go
@@ -615,6 +615,7 @@ func AddMythicService(service string, removeVolume bool) {
 				"JUPYTER_TOKEN=${JUPYTER_TOKEN}",
 				"CHOWN_EXTRA=/projects",
 				"CHOWN_EXTRA_OPTS=-R",
+				"JUPYTER_PORT=${JUPYTER_PORT}",
 			}
 		} else {
 			delete(pStruct, "ports")


### PR DESCRIPTION
## Summary

This PR passes the configured `JUPYTER_PORT` value into the `mythic_jupyter` container environment in bridge networking mode.

The Jupyter Dockerfile already defines `JUPYTER_PORT` and starts Jupyter with `--port=${JUPYTER_PORT}`. The missing piece was the generated Docker Compose service: it mapped `${JUPYTER_PORT}:${JUPYTER_PORT}` but did not pass `JUPYTER_PORT` into the container, so Jupyter kept using the image default of `8888`.

## Problem

When `JUPYTER_PORT` is changed in Mythic's `.env`, Mythic's CLI port checks and Nginx upstream configuration use the configured port, but the Jupyter process inside the container can still listen on the Dockerfile default port.

This can make `/jupyter` fail when the configured port differs from `8888`.

## Fix

Add `JUPYTER_PORT=${JUPYTER_PORT}` to the `mythic_jupyter` service environment generated for bridge networking.

This keeps the Dockerfile default unchanged while allowing runtime `.env` configuration to reach the container process.

## Testing

- Ran `gofmt` with the Go 1.25 Docker toolchain.
- Ran `go test -vet=off ./...` successfully.

Default `go test ./...` is currently blocked by existing `log.Printf` vet findings outside this PR's diff.