### PR TITLE
C2 Profile Build Parameter Updates

### DIFF
--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadBuildParametersTable.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadBuildParametersTable.js
@@ -1,9 +1,20 @@
 import React from 'react';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { CreatePayloadParameter } from './CreatePayloadParameter';
 import {GetGroupedParameters} from "./Step1SelectOS";
 
 
 export function CreatePayloadBuildParametersTable(props){
+    const [collapsedGroups, setCollapsedGroups] = React.useState(new Set());
+    const toggleGroup = (name) => {
+        setCollapsedGroups(prev => {
+            const next = new Set(prev);
+            if(next.has(name)){ next.delete(name); }
+            else { next.add(name); }
+            return next;
+        });
+    };
     const buildParameters = GetGroupedParameters({
         buildParameters: props.buildParameters,
         os: props.os,
@@ -11,29 +22,52 @@ export function CreatePayloadBuildParametersTable(props){
     });
     return (
         <div className="mythic-create-parameter-scroll">
-            {buildParameters.map(b => (
-                b.parameters.length > 0 &&
-                <section className="mythic-create-parameter-group" key={b?.name || 'undefined'}>
-                    {b.name !== '' && b.name !== undefined &&
-                        <div className="mythic-create-parameter-group-header">{b.name}</div>
-                    }
-                    <div className="mythic-create-parameter-list">
-                        {b.parameters.map( (op) => (
-                            <CreatePayloadParameter
-                                displayMode="card"
-                                selected_os={props.os}
-                                key={"buildparamtablerow" + op.id}
-                                payload_type={props.payload_type}
-                                c2_profile_name={props.c2_name}
-                                instance_name={props.instance_name}
-                                onChange={props.onChange}
-                                {...op}
-                            />
-                        ))}
-                    </div>
-                </section>
-            ))}
+            {buildParameters.map(b => {
+                if(b.parameters.length === 0) return null;
+                const hasHeader = b.name !== '' && b.name !== undefined;
+                const collapsed = hasHeader && collapsedGroups.has(b.name);
+                return (
+                    <section className="mythic-create-parameter-group" key={b?.name || 'undefined'}>
+                        {hasHeader &&
+                            <div
+                                className="mythic-create-parameter-group-header"
+                                role="button"
+                                tabIndex={0}
+                                aria-expanded={!collapsed}
+                                aria-label={collapsed ? `Expand ${b.name}` : `Collapse ${b.name}`}
+                                onClick={() => toggleGroup(b.name)}
+                                onKeyDown={(e) => {
+                                    if(e.key === "Enter" || e.key === " "){
+                                        e.preventDefault();
+                                        toggleGroup(b.name);
+                                    }
+                                }}
+                                style={{alignItems: "center", cursor: "pointer", display: "flex", justifyContent: "space-between", userSelect: "none"}}
+                            >
+                                <span>{b.name}</span>
+                                {collapsed ? <ChevronRightIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+                            </div>
+                        }
+                        {!collapsed &&
+                            <div className="mythic-create-parameter-list">
+                                {b.parameters.map( (op) => (
+                                    <CreatePayloadParameter
+                                        displayMode="card"
+                                        selected_os={props.os}
+                                        key={"buildparamtablerow" + op.id}
+                                        payload_type={props.payload_type}
+                                        c2_profile_name={props.c2_name}
+                                        instance_name={props.instance_name}
+                                        onChange={props.onChange}
+                                        {...op}
+                                    />
+                                ))}
+                            </div>
+                        }
+                    </section>
+                );
+            })}
         </div>
 
     );
-} 
+}

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadBuildParametersTable.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadBuildParametersTable.js
@@ -24,6 +24,7 @@ export function CreatePayloadBuildParametersTable(props){
                                 selected_os={props.os}
                                 key={"buildparamtablerow" + op.id}
                                 payload_type={props.payload_type}
+                                c2_profile_name={props.c2_name}
                                 instance_name={props.instance_name}
                                 onChange={props.onChange}
                                 {...op}

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadC2ProfileParametersTable.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadC2ProfileParametersTable.js
@@ -14,6 +14,7 @@ export function CreatePayloadC2ProfileParametersTable(props){
                     displayMode="card"
                     key={"c2paramtablerow" + op.id}
                     returnAllDictValues={props.returnAllDictValues}
+                    c2_profile_name={props.name}
                     onChange={onChange}
                     {...op}
                 />

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -7,7 +7,8 @@ import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
 import MythicTextField from '../../MythicComponents/MythicTextField';
 import DeleteIcon from '@mui/icons-material/Delete';
-import {IconButton, Input, Button, MenuItem, Grid, Dialog, DialogTitle, DialogContent, DialogActions, Chip} from '@mui/material';
+import {IconButton, Input, Button, MenuItem, Grid, Dialog, DialogTitle, DialogContent, DialogActions, Chip, Tabs, Tab, CircularProgress} from '@mui/material';
+import {SchemaFormRenderer, emptyValueForSchema} from './SchemaFormRenderer';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -75,6 +76,7 @@ function getConfigEditorMode(parameterType, randomize, formatString){
     const tail = parts.slice(2);
     let languageHint = "text";
     let randomFn = "";
+    let formFn = "";
     for(const raw of tail){
         const token = raw.trim();
         if(token === ""){ continue; }
@@ -87,8 +89,9 @@ function getConfigEditorMode(parameterType, randomize, formatString){
         const key = token.slice(0, eq).trim().toLowerCase();
         const value = token.slice(eq + 1).trim();
         if(key === "random_fn"){ randomFn = value; }
+        else if(key === "form_fn"){ formFn = value; }
     }
-    return {languageHint, randomFn};
+    return {languageHint, randomFn, formFn};
 }
 function getConfigStatus(value, languageHint){
     const raw = (value ?? "");
@@ -168,6 +171,10 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
     const [configEditorOpen, setConfigEditorOpen] = React.useState(false);
     const aceEditorRef = React.useRef(null);
     const preRandomValueRef = React.useRef("");
+    const [editorTab, setEditorTab] = React.useState('source');
+    const [formSchema, setFormSchema] = React.useState(null);
+    const [formSchemaError, setFormSchemaError] = React.useState("");
+    const [visualParseError, setVisualParseError] = React.useState("");
     const [value, setValue] = React.useState("");
     const [valueNum, setValueNum] = React.useState(0);
     const [multiValue, setMultiValue] = React.useState([]);
@@ -249,6 +256,37 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
             setBackdropOpen(false);
         }
     });
+    const [fetchFormSchema, {loading: formSchemaLoading}] = useMutation(c2CustomRPCFunctionMutation, {
+        onCompleted: (data) => {
+            if(data?.c2CustomRPCFunction?.status === "success"){
+                const result = data.c2CustomRPCFunction.result || {};
+                if(result.schema && typeof result.schema === "object"){
+                    setFormSchema(result.schema);
+                    setFormSchemaError("");
+                } else {
+                    setFormSchemaError("Schema RPC returned no schema");
+                }
+            } else {
+                setFormSchemaError(data?.c2CustomRPCFunction?.error || "Failed to fetch form schema");
+            }
+        },
+        onError: (err) => {
+            setFormSchemaError("Failed to reach C2 custom RPC");
+            console.log(err);
+        }
+    });
+    React.useEffect(() => {
+        if(!configEditorOpen) return;
+        if(!configEditorMode?.formFn) return;
+        if(formSchema) return;
+        if(formSchemaLoading) return;
+        if(!c2_profile_name) return;
+        fetchFormSchema({variables: {
+            c2_profile: c2_profile_name,
+            function_name: configEditorMode.formFn,
+            arguments: {},
+        }});
+    }, [configEditorOpen, configEditorMode?.formFn]);
     const [invokeC2CustomRPC, {loading: c2CustomRPCLoading}] = useMutation(c2CustomRPCFunctionMutation, {
         onCompleted: (data) => {
             if(data?.c2CustomRPCFunction?.status === "success"){
@@ -488,6 +526,37 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
             snackActions.info("Only JSON formatting is available inline. TOML input is left as-is.");
         }
     }
+    const parseSourceForVisual = () => {
+        const raw = (value ?? "").trim();
+        if(raw === ""){
+            return formSchema ? emptyValueForSchema(formSchema) : {};
+        }
+        return JSON.parse(raw);
+    };
+    const visualValue = React.useMemo(() => {
+        if(editorTab !== 'visual') return null;
+        try { return parseSourceForVisual(); }
+        catch(_) { return null; }
+    }, [editorTab, value, formSchema]);
+    const onVisualChange = (newVal) => {
+        try {
+            const serialized = JSON.stringify(newVal, null, 2);
+            onChangeText(name, serialized, testParameterValues(serialized));
+        } catch(e) {
+            snackActions.warning("Failed to serialize visual form state");
+            console.log(e);
+        }
+    };
+    const onSwitchToVisual = () => {
+        try {
+            parseSourceForVisual();
+            setVisualParseError("");
+            setEditorTab('visual');
+        } catch(e) {
+            setVisualParseError(e.message || String(e));
+            setEditorTab('source');
+        }
+    };
     const showUndoSnackbar = (label, previousValue) => {
         snackActions.info(
             <span style={{display: "inline-flex", alignItems: "center", gap: "8px"}}>
@@ -944,35 +1013,78 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                                 </div>
                             </Paper>
                             <Dialog open={configEditorOpen} onClose={() => setConfigEditorOpen(false)} maxWidth="lg" fullWidth>
-                                <DialogTitle>{name}</DialogTitle>
+                                <DialogTitle style={{paddingBottom: 0}}>
+                                    {display_name && display_name.length > 0 ? display_name : name}
+                                    {configEditorMode.formFn && (
+                                        <Tabs value={editorTab}
+                                              onChange={(e, v) => { if(v === 'visual'){ onSwitchToVisual(); } else { setEditorTab('source'); } }}
+                                              style={{marginTop: "4px", minHeight: "32px"}}
+                                              TabIndicatorProps={{style: {height: "2px"}}}>
+                                            <Tab value="visual" label="Visual" style={{minHeight: "32px", textTransform: "none"}} />
+                                            <Tab value="source" label="Source" style={{minHeight: "32px", textTransform: "none"}} />
+                                        </Tabs>
+                                    )}
+                                </DialogTitle>
                                 <DialogContent dividers>
-                                    <div style={{display: "flex", gap: "8px", alignItems: "center", marginBottom: "8px", flexWrap: "wrap"}}>
-                                        <Typography variant="caption" color="text.secondary" style={{flex: "1 1 auto"}}>
-                                            Paste configuration inline, upload a local JSON/TOML file, or leave empty for default behavior without transforms.
-                                        </Typography>
-                                        <Button variant="text" size="small" onClick={onFormatConfigEditorJson}>
-                                            Format
-                                        </Button>
-                                        <Button variant="text" size="small" onClick={onCopyConfigToClipboard}>
-                                            Copy
-                                        </Button>
-                                    </div>
-                                    <AceEditor
-                                        mode={aceMode}
-                                        theme={theme.palette.mode === 'dark' ? 'monokai' : 'github'}
-                                        width="100%"
-                                        minLines={20}
-                                        maxLines={40}
-                                        showPrintMargin={false}
-                                        wrapEnabled={true}
-                                        value={value}
-                                        placeholder={getConfigEditorPlaceholder(configEditorMode.languageHint)}
-                                        onChange={(newValue) => onChangeText(name, newValue, testParameterValues(newValue))}
-                                        setOptions={{useWorker: false, tabSize: 2, useSoftTabs: true}}
-                                        name={"ace_config_editor_" + id}
-                                        onLoad={(editor) => { aceEditorRef.current = editor; }}
-                                        editorProps={{$blockScrolling: true}}
-                                    />
+                                    {(!configEditorMode.formFn || editorTab === 'source') && (
+                                        <React.Fragment>
+                                            <div style={{display: "flex", gap: "8px", alignItems: "center", marginBottom: "8px", flexWrap: "wrap"}}>
+                                                <Typography variant="caption" color="text.secondary" style={{flex: "1 1 auto"}}>
+                                                    Paste configuration inline, upload a local JSON/TOML file, or leave empty for default behavior without transforms.
+                                                </Typography>
+                                                <Button variant="text" size="small" onClick={onFormatConfigEditorJson}>
+                                                    Format
+                                                </Button>
+                                                <Button variant="text" size="small" onClick={onCopyConfigToClipboard}>
+                                                    Copy
+                                                </Button>
+                                            </div>
+                                            {visualParseError && (
+                                                <Typography variant="caption" color="error" style={{display: "block", marginBottom: "4px"}}>
+                                                    Visual tab unavailable: {visualParseError}
+                                                </Typography>
+                                            )}
+                                            <AceEditor
+                                                mode={aceMode}
+                                                theme={theme.palette.mode === 'dark' ? 'monokai' : 'github'}
+                                                width="100%"
+                                                minLines={20}
+                                                maxLines={40}
+                                                showPrintMargin={false}
+                                                wrapEnabled={true}
+                                                value={value}
+                                                placeholder={getConfigEditorPlaceholder(configEditorMode.languageHint)}
+                                                onChange={(newValue) => onChangeText(name, newValue, testParameterValues(newValue))}
+                                                setOptions={{useWorker: false, tabSize: 2, useSoftTabs: true}}
+                                                name={"ace_config_editor_" + id}
+                                                onLoad={(editor) => { aceEditorRef.current = editor; }}
+                                                editorProps={{$blockScrolling: true}}
+                                            />
+                                        </React.Fragment>
+                                    )}
+                                    {configEditorMode.formFn && editorTab === 'visual' && (
+                                        <React.Fragment>
+                                            {formSchemaLoading && (
+                                                <div style={{display: "flex", gap: "8px", alignItems: "center", padding: "24px", justifyContent: "center"}}>
+                                                    <CircularProgress size={20} />
+                                                    <Typography variant="body2">Loading form schema…</Typography>
+                                                </div>
+                                            )}
+                                            {!formSchemaLoading && formSchemaError && (
+                                                <Typography variant="body2" color="error">
+                                                    {formSchemaError}
+                                                </Typography>
+                                            )}
+                                            {!formSchemaLoading && !formSchemaError && formSchema && visualValue !== null && (
+                                                <SchemaFormRenderer schema={formSchema} value={visualValue} onChange={onVisualChange} />
+                                            )}
+                                            {!formSchemaLoading && !formSchemaError && !formSchema && (
+                                                <Typography variant="body2" color="text.secondary">
+                                                    Form schema has not been fetched yet. Open the editor again after the container is reachable.
+                                                </Typography>
+                                            )}
+                                        </React.Fragment>
+                                    )}
                                 </DialogContent>
                                 <DialogActions>
                                     <Button onClick={() => setConfigEditorOpen(false)}>Close</Button>

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -26,6 +26,8 @@ import {CircularProgress} from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import InputLabel from '@mui/material/InputLabel';
 import {DragAndDropFileUpload} from "../Callbacks/TaskParametersDialogRow";
+import Paper from '@mui/material/Paper';
+import TextField from '@mui/material/TextField';
 
 export const getDynamicQueryBuildParameterParams = gql`
 mutation getDynamicBuildParamsMutation($payload_type: String!, $parameter_name: String!, $selected_os: String!){
@@ -46,10 +48,59 @@ function isTrue(value){
     }
     console.log("unknown boolean value", value);
 }
+function getConfigEditorMode(parameterType, randomize, formatString){
+    if(parameterType !== "String" || randomize || typeof formatString !== "string"){
+        return null;
+    }
+    const normalized = formatString.trim().toLowerCase();
+    if(!normalized.startsWith("ui:config_editor")){
+        return null;
+    }
+    const parts = normalized.split(":");
+    return {
+        languageHint: parts.length > 2 ? parts.slice(2).join(":") : "text"
+    };
+}
+function getConfigEditorPlaceholder(languageHint){
+    switch(languageHint){
+        case "json_toml":
+            return `{
+  "name": "example",
+  "post": {
+    "uris": ["/"],
+    "client": {
+      "message": {
+        "location": "body"
+      }
+    }
+  }
+}
+
+# Or TOML:
+# name = "example"
+# [post]
+# uris = ["/"]`;
+        case "json":
+            return `{
+  "name": "example",
+  "post": {
+    "uris": ["/"]
+  }
+}`;
+        case "toml":
+            return `name = "example"
+[post]
+uris = ["/"]`;
+        default:
+            return "";
+    }
+}
 export function CreatePayloadParameter({onChange, parameter_type, default_value, name, required, verifier_regex, id,
                                            description, initialValue, choices, trackedValue, instance_name,
-                                           payload_type, selected_os, dynamic_query_function, displayMode = "table"}){
+                                           payload_type, selected_os, dynamic_query_function, randomize, format_string,
+                                           displayMode = "table"}){
     const theme = useTheme();
+    const configEditorMode = getConfigEditorMode(parameter_type, randomize, format_string);
     const [value, setValue] = React.useState("");
     const [valueNum, setValueNum] = React.useState(0);
     const [multiValue, setMultiValue] = React.useState([]);
@@ -305,6 +356,38 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
     const onChangeText = (name, value, error) => {
         setValue(value);
         onChange(name, value, error);
+    }
+    const onConfigEditorUpload = async (evt) => {
+        const file = evt.target.files?.[0];
+        if(!file){
+            return;
+        }
+        try{
+            const uploadedValue = await file.text();
+            setValue(uploadedValue);
+            onChange(name, uploadedValue, testParameterValues(uploadedValue));
+        }catch(error){
+            snackActions.warning("Failed to read uploaded configuration file");
+            console.error(error);
+        }finally{
+            evt.target.value = "";
+        }
+    }
+    const onFormatConfigEditorJson = () => {
+        if(value.trim() === ""){
+            return;
+        }
+        try{
+            const formattedValue = JSON.stringify(JSON.parse(value), null, 2);
+            setValue(formattedValue);
+            onChange(name, formattedValue, testParameterValues(formattedValue));
+        }catch(error){
+            snackActions.info("Only JSON formatting is available inline. TOML input is left as-is.");
+        }
+    }
+    const onClearConfigEditor = () => {
+        setValue("");
+        onChange(name, "", testParameterValues(""));
     }
     const onChangeNumber = (name, value, error) => {
         setValueNum(value);
@@ -684,6 +767,43 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                     </React.Fragment>
                 );
             case "String":
+                if(configEditorMode !== null){
+                    return (
+                        <Paper variant="outlined" style={{padding: "12px"}}>
+                            <div style={{display: "flex", gap: "8px", alignItems: "center", marginBottom: "8px", flexWrap: "wrap"}}>
+                                <div>
+                                    <Button variant="outlined" component="label" size="small">
+                                        Upload JSON/TOML
+                                        <input onChange={onConfigEditorUpload} type="file" hidden accept=".json,.toml,.txt,application/json,text/plain" />
+                                    </Button>
+                                </div>
+                                <div>
+                                    <Button variant="text" size="small" onClick={onFormatConfigEditorJson}>
+                                        Format JSON
+                                    </Button>
+                                </div>
+                                <div>
+                                    <Button variant="text" size="small" color="warning" onClick={onClearConfigEditor}>
+                                        Clear
+                                    </Button>
+                                </div>
+                            </div>
+                            <Typography variant="caption" color="text.secondary" style={{display: "block", marginBottom: "8px"}}>
+                                Paste configuration inline, upload a local JSON/TOML file, or leave this empty for default behavior without transforms.
+                            </Typography>
+                            <TextField
+                                fullWidth
+                                multiline
+                                minRows={14}
+                                value={value}
+                                onChange={(evt) => onChangeText(name, evt.target.value, testParameterValues(evt.target.value))}
+                                placeholder={getConfigEditorPlaceholder(configEditorMode.languageHint)}
+                                variant="outlined"
+                                inputProps={{spellCheck: "false", style: {fontFamily: "Consolas, 'Courier New', monospace", fontSize: "0.85rem", lineHeight: 1.5}}}
+                            />
+                        </Paper>
+                    );
+                }
                 return (
                     <MythicTextField required={required} value={value} multiline={true}
                         onChange={onChangeText} display="inline-block" name={name} showLabel={false}

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -93,7 +93,7 @@ function getConfigEditorMode(parameterType, randomize, formatString){
 function getConfigStatus(value, languageHint){
     const raw = (value ?? "");
     const trimmed = raw.trim();
-    if(trimmed === ""){ return {kind: "empty", label: "Empty — using default"}; }
+    if(trimmed === ""){ return {kind: "empty", label: "Using default"}; }
     const lineCount = raw.split(/\r?\n/).length;
     // only validate when the content is plausibly JSON
     const looksJson = trimmed.startsWith("{") || trimmed.startsWith("[");
@@ -926,10 +926,12 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                                         Edit
                                     </Button>
                                     <div style={{marginLeft: "auto", display: "flex", gap: "6px", alignItems: "center"}}>
-                                        <Chip size="small" label={status.label} color={chipColor} />
-                                        <Typography variant="caption" color="text.secondary">
-                                            {aceMode.toUpperCase()}
-                                        </Typography>
+                                        <MythicStyledTooltip title="Open editor">
+                                            <Chip size="small" label={status.label} color={chipColor}
+                                                  clickable
+                                                  onClick={() => setConfigEditorOpen(true)} />
+                                        </MythicStyledTooltip>
+                                        <Chip size="small" variant="outlined" label={aceMode.toUpperCase()} />
                                     </div>
                                 </div>
                             </Paper>

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -976,10 +976,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                                     </Button>
                                     {hasPresets && (
                                         <FormControl size="small" style={{minWidth: "180px"}} disabled={c2CustomRPCLoading}>
-                                            <InputLabel id={"preset_label_" + id}>Preset</InputLabel>
                                             <Select
-                                                labelId={"preset_label_" + id}
-                                                label="Preset"
                                                 value={matchingPresetFilename}
                                                 displayEmpty
                                                 renderValue={(selected) => {

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -276,9 +276,14 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
         }
     });
     React.useEffect(() => {
-        if(!configEditorOpen) return;
+        // Refetch schema each time the modal opens so updates on the
+        // container side propagate without requiring a page reload.
+        if(!configEditorOpen){
+            setFormSchema(null);
+            setFormSchemaError("");
+            return;
+        }
         if(!configEditorMode?.formFn) return;
-        if(formSchema) return;
         if(formSchemaLoading) return;
         if(!c2_profile_name) return;
         fetchFormSchema({variables: {

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -154,7 +154,7 @@ uris = ["/"]`;
 export function CreatePayloadParameter({onChange, parameter_type, default_value, name, required, verifier_regex, id,
                                            description, initialValue, choices, trackedValue, instance_name,
                                            payload_type, selected_os, dynamic_query_function, randomize, format_string,
-                                           c2_profile_name, displayMode = "table"}){
+                                           c2_profile_name, display_name, displayMode = "table"}){
     const theme = useTheme();
     const configEditorMode = getConfigEditorMode(parameter_type, randomize, format_string);
     const [configEditorOpen, setConfigEditorOpen] = React.useState(false);
@@ -1115,7 +1115,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                 <MythicStyledTableCell>
                     <MythicStyledTooltip title={name.length > 0 ? name : "No Description"}>
                         <Typography style={{fontWeight: "600"}} >
-                            {name}
+                            {display_name && display_name.length > 0 ? display_name : name}
                         </Typography>
                         <Typography style={{fontSize: theme.typography.pxToRem(15), marginLeft: "10px"}}>
                             {description}

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -7,7 +7,7 @@ import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
 import MythicTextField from '../../MythicComponents/MythicTextField';
 import DeleteIcon from '@mui/icons-material/Delete';
-import {IconButton, Input, Button, MenuItem, Grid} from '@mui/material';
+import {IconButton, Input, Button, MenuItem, Grid, Dialog, DialogTitle, DialogContent, DialogActions, Chip} from '@mui/material';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -44,6 +44,15 @@ mutation getDynamicBuildParamsMutation($payload_type: String!, $parameter_name: 
     }
 }
 `;
+export const c2CustomRPCFunctionMutation = gql`
+mutation c2CustomRPCFunctionMutation($c2_profile: String!, $function_name: String!, $arguments: jsonb){
+    c2CustomRPCFunction(c2_profile: $c2_profile, function_name: $function_name, arguments: $arguments){
+        status
+        error
+        result
+    }
+}
+`;
 function isTrue(value){
     if(typeof value === 'boolean'){
         return value;
@@ -57,14 +66,46 @@ function getConfigEditorMode(parameterType, randomize, formatString){
     if(parameterType !== "String" || randomize || typeof formatString !== "string"){
         return null;
     }
-    const normalized = formatString.trim().toLowerCase();
-    if(!normalized.startsWith("ui:config_editor")){
+    const normalized = formatString.trim();
+    if(!normalized.toLowerCase().startsWith("ui:config_editor")){
         return null;
     }
+    // tokens after "ui:config_editor": first is the language hint, remaining are key=value suffixes
     const parts = normalized.split(":");
-    return {
-        languageHint: parts.length > 2 ? parts.slice(2).join(":") : "text"
-    };
+    const tail = parts.slice(2);
+    let languageHint = "text";
+    let randomFn = "";
+    for(const raw of tail){
+        const token = raw.trim();
+        if(token === ""){ continue; }
+        const eq = token.indexOf("=");
+        if(eq === -1){
+            // bare token → language hint (first one wins)
+            if(languageHint === "text"){ languageHint = token.toLowerCase(); }
+            continue;
+        }
+        const key = token.slice(0, eq).trim().toLowerCase();
+        const value = token.slice(eq + 1).trim();
+        if(key === "random_fn"){ randomFn = value; }
+    }
+    return {languageHint, randomFn};
+}
+function getConfigStatus(value, languageHint){
+    const raw = (value ?? "");
+    const trimmed = raw.trim();
+    if(trimmed === ""){ return {kind: "empty", label: "Empty — using default"}; }
+    const lineCount = raw.split(/\r?\n/).length;
+    // only validate when the content is plausibly JSON
+    const looksJson = trimmed.startsWith("{") || trimmed.startsWith("[");
+    if(looksJson){
+        try{
+            JSON.parse(trimmed);
+        }catch(e){
+            return {kind: "invalid", label: "Invalid JSON"};
+        }
+    }
+    const format = (looksJson ? "JSON" : (languageHint === "toml" || languageHint === "json_toml" ? "TOML" : "TEXT"));
+    return {kind: "set", label: `Custom · ${lineCount} line${lineCount === 1 ? "" : "s"}`, format};
 }
 function detectAceMode(languageHint, content){
     if(languageHint === "json"){ return "json"; }
@@ -113,9 +154,10 @@ uris = ["/"]`;
 export function CreatePayloadParameter({onChange, parameter_type, default_value, name, required, verifier_regex, id,
                                            description, initialValue, choices, trackedValue, instance_name,
                                            payload_type, selected_os, dynamic_query_function, randomize, format_string,
-                                           displayMode = "table"}){
+                                           c2_profile_name, displayMode = "table"}){
     const theme = useTheme();
     const configEditorMode = getConfigEditorMode(parameter_type, randomize, format_string);
+    const [configEditorOpen, setConfigEditorOpen] = React.useState(false);
     const [value, setValue] = React.useState("");
     const [valueNum, setValueNum] = React.useState(0);
     const [multiValue, setMultiValue] = React.useState([]);
@@ -197,6 +239,37 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
             setBackdropOpen(false);
         }
     });
+    const [invokeC2CustomRPC, {loading: c2CustomRPCLoading}] = useMutation(c2CustomRPCFunctionMutation, {
+        onCompleted: (data) => {
+            if(data?.c2CustomRPCFunction?.status === "success"){
+                const result = data.c2CustomRPCFunction.result || {};
+                const newValue = typeof result.value === "string" ? result.value : "";
+                if(newValue !== ""){
+                    onChangeText(name, newValue, testParameterValues(newValue));
+                } else {
+                    snackActions.warning("Random generator returned no value");
+                }
+            } else {
+                snackActions.warning(data?.c2CustomRPCFunction?.error || "Custom RPC failed");
+            }
+        },
+        onError: (err) => {
+            snackActions.warning("Failed to invoke C2 custom RPC");
+            console.log(err);
+        }
+    });
+    const onInvokeRandomFn = () => {
+        if(!configEditorMode || !configEditorMode.randomFn){ return; }
+        if(!c2_profile_name){
+            snackActions.warning("Random generate not available: missing c2 profile context");
+            return;
+        }
+        invokeC2CustomRPC({variables: {
+            c2_profile: c2_profile_name,
+            function_name: configEditorMode.randomFn,
+            arguments: {},
+        }});
+    };
     const reIssueDynamicQueryFunction = () => {
         setBackdropOpen(true);
         snackActions.info("Querying payload type container for options...",  {autoClose: 1000});
@@ -784,48 +857,66 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
             case "String":
                 if(configEditorMode !== null){
                     const aceMode = detectAceMode(configEditorMode.languageHint, value);
+                    const status = getConfigStatus(value, configEditorMode.languageHint);
+                    const hasRandomFn = !!configEditorMode.randomFn;
+                    const chipColor = status.kind === "invalid" ? "error" : status.kind === "set" ? "success" : "default";
                     return (
-                        <Paper variant="outlined" style={{padding: "12px"}}>
-                            <div style={{display: "flex", gap: "8px", alignItems: "center", marginBottom: "8px", flexWrap: "wrap"}}>
-                                <div>
+                        <React.Fragment>
+                            <Paper variant="outlined" style={{padding: "8px 12px"}}>
+                                <div style={{display: "flex", gap: "8px", alignItems: "center", flexWrap: "wrap"}}>
                                     <Button variant="outlined" component="label" size="small">
-                                        Upload JSON/TOML
+                                        Upload
                                         <input onChange={onConfigEditorUpload} type="file" hidden accept=".json,.toml,.txt,application/json,text/plain" />
                                     </Button>
-                                </div>
-                                <div>
                                     <Button variant="text" size="small" onClick={onFormatConfigEditorJson}>
-                                        Format JSON
+                                        Format
                                     </Button>
-                                </div>
-                                <div>
+                                    {hasRandomFn && (
+                                        <Button variant="text" size="small" onClick={onInvokeRandomFn} disabled={c2CustomRPCLoading}>
+                                            {c2CustomRPCLoading ? "Generating…" : "Random"}
+                                        </Button>
+                                    )}
                                     <Button variant="text" size="small" color="warning" onClick={onClearConfigEditor}>
                                         Clear
                                     </Button>
+                                    <Button variant="contained" size="small" onClick={() => setConfigEditorOpen(true)}>
+                                        Edit
+                                    </Button>
+                                    <div style={{marginLeft: "auto", display: "flex", gap: "6px", alignItems: "center"}}>
+                                        <Chip size="small" label={status.label} color={chipColor} />
+                                        <Typography variant="caption" color="text.secondary">
+                                            {aceMode.toUpperCase()}
+                                        </Typography>
+                                    </div>
                                 </div>
-                                <Typography variant="caption" color="text.secondary" style={{marginLeft: "auto"}}>
-                                    {aceMode.toUpperCase()}
-                                </Typography>
-                            </div>
-                            <Typography variant="caption" color="text.secondary" style={{display: "block", marginBottom: "8px"}}>
-                                Paste configuration inline, upload a local JSON/TOML file, or leave this empty for default behavior without transforms.
-                            </Typography>
-                            <AceEditor
-                                mode={aceMode}
-                                theme={theme.palette.mode === 'dark' ? 'monokai' : 'github'}
-                                width="100%"
-                                minLines={14}
-                                maxLines={30}
-                                showPrintMargin={false}
-                                wrapEnabled={true}
-                                value={value}
-                                placeholder={getConfigEditorPlaceholder(configEditorMode.languageHint)}
-                                onChange={(newValue) => onChangeText(name, newValue, testParameterValues(newValue))}
-                                setOptions={{useWorker: false, tabSize: 2, useSoftTabs: true}}
-                                name={"ace_config_editor_" + id}
-                                editorProps={{$blockScrolling: true}}
-                            />
-                        </Paper>
+                            </Paper>
+                            <Dialog open={configEditorOpen} onClose={() => setConfigEditorOpen(false)} maxWidth="lg" fullWidth>
+                                <DialogTitle>{name}</DialogTitle>
+                                <DialogContent dividers>
+                                    <Typography variant="caption" color="text.secondary" style={{display: "block", marginBottom: "8px"}}>
+                                        Paste configuration inline, upload a local JSON/TOML file, or leave this empty for default behavior without transforms.
+                                    </Typography>
+                                    <AceEditor
+                                        mode={aceMode}
+                                        theme={theme.palette.mode === 'dark' ? 'monokai' : 'github'}
+                                        width="100%"
+                                        minLines={20}
+                                        maxLines={40}
+                                        showPrintMargin={false}
+                                        wrapEnabled={true}
+                                        value={value}
+                                        placeholder={getConfigEditorPlaceholder(configEditorMode.languageHint)}
+                                        onChange={(newValue) => onChangeText(name, newValue, testParameterValues(newValue))}
+                                        setOptions={{useWorker: false, tabSize: 2, useSoftTabs: true}}
+                                        name={"ace_config_editor_" + id}
+                                        editorProps={{$blockScrolling: true}}
+                                    />
+                                </DialogContent>
+                                <DialogActions>
+                                    <Button onClick={() => setConfigEditorOpen(false)}>Close</Button>
+                                </DialogActions>
+                            </Dialog>
+                        </React.Fragment>
                     );
                 }
                 return (

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -75,7 +75,7 @@ function getConfigEditorMode(parameterType, randomize, formatString){
     const parts = normalized.split(":");
     const tail = parts.slice(2);
     let languageHint = "text";
-    let randomFn = "";
+    let presetsFn = "";
     for(const raw of tail){
         const token = raw.trim();
         if(token === ""){ continue; }
@@ -87,9 +87,9 @@ function getConfigEditorMode(parameterType, randomize, formatString){
         }
         const key = token.slice(0, eq).trim().toLowerCase();
         const value = token.slice(eq + 1).trim();
-        if(key === "random_fn"){ randomFn = value; }
+        if(key === "presets_fn"){ presetsFn = value; }
     }
-    return {languageHint, randomFn};
+    return {languageHint, presetsFn};
 }
 function getConfigStatus(value, languageHint){
     const raw = (value ?? "");
@@ -168,7 +168,8 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
     };
     const [configEditorOpen, setConfigEditorOpen] = React.useState(false);
     const aceEditorRef = React.useRef(null);
-    const preRandomValueRef = React.useRef("");
+    const prePresetValueRef = React.useRef("");
+    const [configEditorPresets, setConfigEditorPresets] = React.useState([]);
     const [editorTab, setEditorTab] = React.useState('source');
     const [visualParseError, setVisualParseError] = React.useState("");
     const [value, setValue] = React.useState("");
@@ -260,15 +261,15 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
         onCompleted: (data) => {
             if(data?.c2CustomRPCFunction?.status === "success"){
                 const result = data.c2CustomRPCFunction.result || {};
-                const newValue = typeof result.value === "string" ? result.value : "";
-                if(newValue !== ""){
-                    const prev = preRandomValueRef.current;
-                    onChangeText(name, newValue, testParameterValues(newValue));
-                    if(prev !== ""){
-                        showUndoSnackbar("Random config generated.", prev);
-                    }
-                } else {
-                    snackActions.warning("Random generator returned no value");
+                if(Array.isArray(result.presets)){
+                    const cleaned = result.presets
+                        .filter(p => p && typeof p.filename === "string" && typeof p.content === "string")
+                        .map(p => ({
+                            filename: p.filename,
+                            label: typeof p.label === "string" && p.label.length > 0 ? p.label : p.filename,
+                            content: p.content,
+                        }));
+                    setConfigEditorPresets(cleaned);
                 }
             } else {
                 snackActions.warning(data?.c2CustomRPCFunction?.error || "Custom RPC failed");
@@ -279,18 +280,25 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
             console.log(err);
         }
     });
-    const onInvokeRandomFn = () => {
-        if(!configEditorMode || !configEditorMode.randomFn){ return; }
-        if(!c2_profile_name){
-            snackActions.warning("Random generate not available: missing c2 profile context");
-            return;
-        }
-        preRandomValueRef.current = value ?? "";
+    useEffect(() => {
+        if(!configEditorMode || !configEditorMode.presetsFn || !c2_profile_name){ return; }
         invokeC2CustomRPC({variables: {
             c2_profile: c2_profile_name,
-            function_name: configEditorMode.randomFn,
+            function_name: configEditorMode.presetsFn,
             arguments: {},
         }});
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [c2_profile_name, configEditorMode?.presetsFn]);
+    const onSelectPreset = (filename) => {
+        if(!filename){ return; }
+        const preset = configEditorPresets.find(p => p.filename === filename);
+        if(!preset){ return; }
+        const prev = value ?? "";
+        prePresetValueRef.current = prev;
+        onChangeText(name, preset.content, testParameterValues(preset.content));
+        if(prev !== "" && prev !== preset.content){
+            showUndoSnackbar(`Loaded preset "${preset.label}".`, prev);
+        }
     };
     const reIssueDynamicQueryFunction = () => {
         setBackdropOpen(true);
@@ -950,7 +958,13 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                 if(configEditorMode !== null){
                     const aceMode = detectAceMode(configEditorMode.languageHint, value);
                     const status = getConfigStatus(value, configEditorMode.languageHint);
-                    const hasRandomFn = !!configEditorMode.randomFn;
+                    const hasPresets = !!configEditorMode.presetsFn && configEditorPresets.length > 0;
+                    const matchingPresetFilename = (() => {
+                        const v = value ?? "";
+                        if(v === ""){ return ""; }
+                        const match = configEditorPresets.find(p => p.content === v);
+                        return match ? match.filename : "";
+                    })();
                     const chipColor = status.kind === "invalid" ? "error" : status.kind === "set" ? "success" : "default";
                     return (
                         <React.Fragment>
@@ -960,10 +974,25 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                                         Upload
                                         <input onChange={onConfigEditorUpload} type="file" hidden accept=".json,.toml,.txt,application/json,text/plain" />
                                     </Button>
-                                    {hasRandomFn && (
-                                        <Button variant="text" size="small" onClick={onInvokeRandomFn} disabled={c2CustomRPCLoading}>
-                                            {c2CustomRPCLoading ? "Generating…" : "Random"}
-                                        </Button>
+                                    {hasPresets && (
+                                        <FormControl size="small" style={{minWidth: "180px"}} disabled={c2CustomRPCLoading}>
+                                            <InputLabel id={"preset_label_" + id}>Preset</InputLabel>
+                                            <Select
+                                                labelId={"preset_label_" + id}
+                                                label="Preset"
+                                                value={matchingPresetFilename}
+                                                displayEmpty
+                                                renderValue={(selected) => {
+                                                    if(!selected){ return <em style={{opacity: 0.6}}>Choose a preset…</em>; }
+                                                    const p = configEditorPresets.find(x => x.filename === selected);
+                                                    return p ? p.label : selected;
+                                                }}
+                                                onChange={(e) => onSelectPreset(e.target.value)}>
+                                                {configEditorPresets.map(p => (
+                                                    <MenuItem key={p.filename} value={p.filename}>{p.label}</MenuItem>
+                                                ))}
+                                            </Select>
+                                        </FormControl>
                                     )}
                                     <Button variant="text" size="small" color="warning" onClick={onClearConfigEditor}>
                                         Clear

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -27,7 +27,12 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import InputLabel from '@mui/material/InputLabel';
 import {DragAndDropFileUpload} from "../Callbacks/TaskParametersDialogRow";
 import Paper from '@mui/material/Paper';
-import TextField from '@mui/material/TextField';
+import AceEditor from 'react-ace';
+import 'ace-builds/src-noconflict/mode-json';
+import 'ace-builds/src-noconflict/mode-toml';
+import 'ace-builds/src-noconflict/theme-github';
+import 'ace-builds/src-noconflict/theme-monokai';
+import 'ace-builds/src-noconflict/ext-searchbox';
 
 export const getDynamicQueryBuildParameterParams = gql`
 mutation getDynamicBuildParamsMutation($payload_type: String!, $parameter_name: String!, $selected_os: String!){
@@ -60,6 +65,16 @@ function getConfigEditorMode(parameterType, randomize, formatString){
     return {
         languageHint: parts.length > 2 ? parts.slice(2).join(":") : "text"
     };
+}
+function detectAceMode(languageHint, content){
+    if(languageHint === "json"){ return "json"; }
+    if(languageHint === "toml"){ return "toml"; }
+    // json_toml (or anything else): sniff content
+    const trimmed = (content || "").trim();
+    if(trimmed === "" || trimmed.startsWith("{") || trimmed.startsWith("[")){
+        return "json";
+    }
+    return "toml";
 }
 function getConfigEditorPlaceholder(languageHint){
     switch(languageHint){
@@ -768,6 +783,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                 );
             case "String":
                 if(configEditorMode !== null){
+                    const aceMode = detectAceMode(configEditorMode.languageHint, value);
                     return (
                         <Paper variant="outlined" style={{padding: "12px"}}>
                             <div style={{display: "flex", gap: "8px", alignItems: "center", marginBottom: "8px", flexWrap: "wrap"}}>
@@ -787,19 +803,27 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                                         Clear
                                     </Button>
                                 </div>
+                                <Typography variant="caption" color="text.secondary" style={{marginLeft: "auto"}}>
+                                    {aceMode.toUpperCase()}
+                                </Typography>
                             </div>
                             <Typography variant="caption" color="text.secondary" style={{display: "block", marginBottom: "8px"}}>
                                 Paste configuration inline, upload a local JSON/TOML file, or leave this empty for default behavior without transforms.
                             </Typography>
-                            <TextField
-                                fullWidth
-                                multiline
-                                minRows={14}
+                            <AceEditor
+                                mode={aceMode}
+                                theme={theme.palette.mode === 'dark' ? 'monokai' : 'github'}
+                                width="100%"
+                                minLines={14}
+                                maxLines={30}
+                                showPrintMargin={false}
+                                wrapEnabled={true}
                                 value={value}
-                                onChange={(evt) => onChangeText(name, evt.target.value, testParameterValues(evt.target.value))}
                                 placeholder={getConfigEditorPlaceholder(configEditorMode.languageHint)}
-                                variant="outlined"
-                                inputProps={{spellCheck: "false", style: {fontFamily: "Consolas, 'Courier New', monospace", fontSize: "0.85rem", lineHeight: 1.5}}}
+                                onChange={(newValue) => onChangeText(name, newValue, testParameterValues(newValue))}
+                                setOptions={{useWorker: false, tabSize: 2, useSoftTabs: true}}
+                                name={"ace_config_editor_" + id}
+                                editorProps={{$blockScrolling: true}}
                             />
                         </Paper>
                     );

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -7,7 +7,7 @@ import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
 import MythicTextField from '../../MythicComponents/MythicTextField';
 import DeleteIcon from '@mui/icons-material/Delete';
-import {IconButton, Input, Button, MenuItem, Grid, Dialog, DialogTitle, DialogContent, DialogActions, Chip, Tabs, Tab, CircularProgress} from '@mui/material';
+import {IconButton, Input, Button, MenuItem, Grid, Dialog, DialogTitle, DialogContent, DialogActions, Chip, Tabs, Tab} from '@mui/material';
 import {SchemaFormRenderer, emptyValueForSchema} from './SchemaFormRenderer';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -158,6 +158,8 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
     const theme = useTheme();
     const configEditorMode = getConfigEditorMode(parameter_type, randomize, format_string);
     const [configEditorOpen, setConfigEditorOpen] = React.useState(false);
+    const aceEditorRef = React.useRef(null);
+    const preRandomValueRef = React.useRef("");
     const [value, setValue] = React.useState("");
     const [valueNum, setValueNum] = React.useState(0);
     const [multiValue, setMultiValue] = React.useState([]);
@@ -245,7 +247,11 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                 const result = data.c2CustomRPCFunction.result || {};
                 const newValue = typeof result.value === "string" ? result.value : "";
                 if(newValue !== ""){
+                    const prev = preRandomValueRef.current;
                     onChangeText(name, newValue, testParameterValues(newValue));
+                    if(prev !== ""){
+                        showUndoSnackbar("Random config generated.", prev);
+                    }
                 } else {
                     snackActions.warning("Random generator returned no value");
                 }
@@ -264,6 +270,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
             snackActions.warning("Random generate not available: missing c2 profile context");
             return;
         }
+        preRandomValueRef.current = value ?? "";
         invokeC2CustomRPC({variables: {
             c2_profile: c2_profile_name,
             function_name: configEditorMode.randomFn,
@@ -473,10 +480,49 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
             snackActions.info("Only JSON formatting is available inline. TOML input is left as-is.");
         }
     }
+    const showUndoSnackbar = (label, previousValue) => {
+        snackActions.info(
+            <span style={{display: "inline-flex", alignItems: "center", gap: "8px"}}>
+                {label}
+                <Button size="small" variant="outlined" onClick={(e) => {
+                    e.stopPropagation();
+                    onChangeText(name, previousValue, testParameterValues(previousValue));
+                }}>
+                    Undo
+                </Button>
+            </span>,
+            {autoClose: 8000}
+        );
+    }
     const onClearConfigEditor = () => {
+        const prev = value;
         setValue("");
         onChange(name, "", testParameterValues(""));
+        if(prev !== ""){
+            showUndoSnackbar("Config cleared.", prev);
+        }
     }
+    const onCopyConfigToClipboard = async () => {
+        const raw = value ?? "";
+        if(raw === ""){
+            snackActions.info("Nothing to copy");
+            return;
+        }
+        try{
+            await navigator.clipboard.writeText(raw);
+            snackActions.success("Copied to clipboard");
+        }catch(err){
+            snackActions.warning("Clipboard unavailable");
+            console.error(err);
+        }
+    }
+    React.useEffect(() => {
+        if(!configEditorOpen){ return; }
+        const t = setTimeout(() => {
+            try { aceEditorRef.current?.focus(); } catch(_) {}
+        }, 200);
+        return () => clearTimeout(t);
+    }, [configEditorOpen]);
     const onChangeNumber = (name, value, error) => {
         setValueNum(value);
         onChange(name, value, error);
@@ -868,9 +914,6 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                                         Upload
                                         <input onChange={onConfigEditorUpload} type="file" hidden accept=".json,.toml,.txt,application/json,text/plain" />
                                     </Button>
-                                    <Button variant="text" size="small" onClick={onFormatConfigEditorJson}>
-                                        Format
-                                    </Button>
                                     {hasRandomFn && (
                                         <Button variant="text" size="small" onClick={onInvokeRandomFn} disabled={c2CustomRPCLoading}>
                                             {c2CustomRPCLoading ? "Generating…" : "Random"}
@@ -893,9 +936,17 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                             <Dialog open={configEditorOpen} onClose={() => setConfigEditorOpen(false)} maxWidth="lg" fullWidth>
                                 <DialogTitle>{name}</DialogTitle>
                                 <DialogContent dividers>
-                                    <Typography variant="caption" color="text.secondary" style={{display: "block", marginBottom: "8px"}}>
-                                        Paste configuration inline, upload a local JSON/TOML file, or leave this empty for default behavior without transforms.
-                                    </Typography>
+                                    <div style={{display: "flex", gap: "8px", alignItems: "center", marginBottom: "8px", flexWrap: "wrap"}}>
+                                        <Typography variant="caption" color="text.secondary" style={{flex: "1 1 auto"}}>
+                                            Paste configuration inline, upload a local JSON/TOML file, or leave empty for default behavior without transforms.
+                                        </Typography>
+                                        <Button variant="text" size="small" onClick={onFormatConfigEditorJson}>
+                                            Format
+                                        </Button>
+                                        <Button variant="text" size="small" onClick={onCopyConfigToClipboard}>
+                                            Copy
+                                        </Button>
+                                    </div>
                                     <AceEditor
                                         mode={aceMode}
                                         theme={theme.palette.mode === 'dark' ? 'monokai' : 'github'}
@@ -909,6 +960,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                                         onChange={(newValue) => onChangeText(name, newValue, testParameterValues(newValue))}
                                         setOptions={{useWorker: false, tabSize: 2, useSoftTabs: true}}
                                         name={"ace_config_editor_" + id}
+                                        onLoad={(editor) => { aceEditorRef.current = editor; }}
                                         editorProps={{$blockScrolling: true}}
                                     />
                                 </DialogContent>

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -76,7 +76,6 @@ function getConfigEditorMode(parameterType, randomize, formatString){
     const tail = parts.slice(2);
     let languageHint = "text";
     let randomFn = "";
-    let formFn = "";
     for(const raw of tail){
         const token = raw.trim();
         if(token === ""){ continue; }
@@ -89,9 +88,8 @@ function getConfigEditorMode(parameterType, randomize, formatString){
         const key = token.slice(0, eq).trim().toLowerCase();
         const value = token.slice(eq + 1).trim();
         if(key === "random_fn"){ randomFn = value; }
-        else if(key === "form_fn"){ formFn = value; }
     }
-    return {languageHint, randomFn, formFn};
+    return {languageHint, randomFn};
 }
 function getConfigStatus(value, languageHint){
     const raw = (value ?? "");
@@ -157,7 +155,7 @@ uris = ["/"]`;
 export function CreatePayloadParameter({onChange, parameter_type, default_value, name, required, verifier_regex, id,
                                            description, initialValue, choices, trackedValue, instance_name,
                                            payload_type, selected_os, dynamic_query_function, randomize, format_string,
-                                           c2_profile_name, display_name, choices_display_names,
+                                           c2_profile_name, display_name, choices_display_names, form_schema,
                                            displayMode = "table"}){
     const theme = useTheme();
     const configEditorMode = getConfigEditorMode(parameter_type, randomize, format_string);
@@ -172,8 +170,6 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
     const aceEditorRef = React.useRef(null);
     const preRandomValueRef = React.useRef("");
     const [editorTab, setEditorTab] = React.useState('source');
-    const [formSchema, setFormSchema] = React.useState(null);
-    const [formSchemaError, setFormSchemaError] = React.useState("");
     const [visualParseError, setVisualParseError] = React.useState("");
     const [value, setValue] = React.useState("");
     const [valueNum, setValueNum] = React.useState(0);
@@ -256,42 +252,10 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
             setBackdropOpen(false);
         }
     });
-    const [fetchFormSchema, {loading: formSchemaLoading}] = useMutation(c2CustomRPCFunctionMutation, {
-        onCompleted: (data) => {
-            if(data?.c2CustomRPCFunction?.status === "success"){
-                const result = data.c2CustomRPCFunction.result || {};
-                if(result.schema && typeof result.schema === "object"){
-                    setFormSchema(result.schema);
-                    setFormSchemaError("");
-                } else {
-                    setFormSchemaError("Schema RPC returned no schema");
-                }
-            } else {
-                setFormSchemaError(data?.c2CustomRPCFunction?.error || "Failed to fetch form schema");
-            }
-        },
-        onError: (err) => {
-            setFormSchemaError("Failed to reach C2 custom RPC");
-            console.log(err);
-        }
-    });
-    React.useEffect(() => {
-        // Refetch schema each time the modal opens so updates on the
-        // container side propagate without requiring a page reload.
-        if(!configEditorOpen){
-            setFormSchema(null);
-            setFormSchemaError("");
-            return;
-        }
-        if(!configEditorMode?.formFn) return;
-        if(formSchemaLoading) return;
-        if(!c2_profile_name) return;
-        fetchFormSchema({variables: {
-            c2_profile: c2_profile_name,
-            function_name: configEditorMode.formFn,
-            arguments: {},
-        }});
-    }, [configEditorOpen, configEditorMode?.formFn]);
+    // Form schema is delivered as a parameter-level field via the c2 sync
+    // pipeline — no runtime RPC call required. Treat non-empty objects
+    // with a `type` key as a valid schema.
+    const hasFormSchema = !!(form_schema && typeof form_schema === "object" && !Array.isArray(form_schema) && typeof form_schema.type === "string" && form_schema.type.length > 0);
     const [invokeC2CustomRPC, {loading: c2CustomRPCLoading}] = useMutation(c2CustomRPCFunctionMutation, {
         onCompleted: (data) => {
             if(data?.c2CustomRPCFunction?.status === "success"){
@@ -534,7 +498,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
     const parseSourceForVisual = () => {
         const raw = (value ?? "").trim();
         if(raw === ""){
-            return formSchema ? emptyValueForSchema(formSchema) : {};
+            return hasFormSchema ? emptyValueForSchema(form_schema) : {};
         }
         return JSON.parse(raw);
     };
@@ -542,7 +506,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
         if(editorTab !== 'visual') return null;
         try { return parseSourceForVisual(); }
         catch(_) { return null; }
-    }, [editorTab, value, formSchema]);
+    }, [editorTab, value, form_schema]);
     const onVisualChange = (newVal) => {
         try {
             const serialized = JSON.stringify(newVal, null, 2);
@@ -1020,7 +984,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                             <Dialog open={configEditorOpen} onClose={() => setConfigEditorOpen(false)} maxWidth="lg" fullWidth>
                                 <DialogTitle style={{paddingBottom: 0}}>
                                     {display_name && display_name.length > 0 ? display_name : name}
-                                    {configEditorMode.formFn && (
+                                    {hasFormSchema && (
                                         <Tabs value={editorTab}
                                               onChange={(e, v) => { if(v === 'visual'){ onSwitchToVisual(); } else { setEditorTab('source'); } }}
                                               style={{marginTop: "4px", minHeight: "32px"}}
@@ -1031,7 +995,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                                     )}
                                 </DialogTitle>
                                 <DialogContent dividers>
-                                    {(!configEditorMode.formFn || editorTab === 'source') && (
+                                    {(!hasFormSchema || editorTab === 'source') && (
                                         <React.Fragment>
                                             <div style={{display: "flex", gap: "8px", alignItems: "center", marginBottom: "8px", flexWrap: "wrap"}}>
                                                 <Typography variant="caption" color="text.secondary" style={{flex: "1 1 auto"}}>
@@ -1067,28 +1031,8 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                                             />
                                         </React.Fragment>
                                     )}
-                                    {configEditorMode.formFn && editorTab === 'visual' && (
-                                        <React.Fragment>
-                                            {formSchemaLoading && (
-                                                <div style={{display: "flex", gap: "8px", alignItems: "center", padding: "24px", justifyContent: "center"}}>
-                                                    <CircularProgress size={20} />
-                                                    <Typography variant="body2">Loading form schema…</Typography>
-                                                </div>
-                                            )}
-                                            {!formSchemaLoading && formSchemaError && (
-                                                <Typography variant="body2" color="error">
-                                                    {formSchemaError}
-                                                </Typography>
-                                            )}
-                                            {!formSchemaLoading && !formSchemaError && formSchema && visualValue !== null && (
-                                                <SchemaFormRenderer schema={formSchema} value={visualValue} onChange={onVisualChange} />
-                                            )}
-                                            {!formSchemaLoading && !formSchemaError && !formSchema && (
-                                                <Typography variant="body2" color="text.secondary">
-                                                    Form schema has not been fetched yet. Open the editor again after the container is reachable.
-                                                </Typography>
-                                            )}
-                                        </React.Fragment>
+                                    {hasFormSchema && editorTab === 'visual' && visualValue !== null && (
+                                        <SchemaFormRenderer schema={form_schema} value={visualValue} onChange={onVisualChange} />
                                     )}
                                 </DialogContent>
                                 <DialogActions>

--- a/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js
@@ -154,9 +154,17 @@ uris = ["/"]`;
 export function CreatePayloadParameter({onChange, parameter_type, default_value, name, required, verifier_regex, id,
                                            description, initialValue, choices, trackedValue, instance_name,
                                            payload_type, selected_os, dynamic_query_function, randomize, format_string,
-                                           c2_profile_name, display_name, displayMode = "table"}){
+                                           c2_profile_name, display_name, choices_display_names,
+                                           displayMode = "table"}){
     const theme = useTheme();
     const configEditorMode = getConfigEditorMode(parameter_type, randomize, format_string);
+    const choiceLabel = (val) => {
+        const m = choices_display_names;
+        if(m && typeof m === "object" && val in m && typeof m[val] === "string" && m[val].length > 0){
+            return m[val];
+        }
+        return val;
+    };
     const [configEditorOpen, setConfigEditorOpen] = React.useState(false);
     const aceEditorRef = React.useRef(null);
     const preRandomValueRef = React.useRef("");
@@ -718,7 +726,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                             >
                             {
                                 ChoiceOptions.map((opt, i) => (
-                                    <MenuItem key={"buildparamopt" + i} value={opt}>{opt}</MenuItem>
+                                    <MenuItem key={"buildparamopt" + i} value={opt}>{choiceLabel(opt)}</MenuItem>
                                 ))
                             }
                             </Select>
@@ -749,7 +757,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                                 >
                                     {
                                         ChoiceOptions.map((opt, i) => (
-                                            <MenuItem key={name + i} value={opt}>{opt}</MenuItem>
+                                            <MenuItem key={name + i} value={opt}>{choiceLabel(opt)}</MenuItem>
                                         ))
                                     }
                                 </Select>
@@ -787,7 +795,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                             >
                             {
                                 ChoiceOptions.map((opt, i) => (
-                                    <MenuItem key={"buildparamopt" + i} value={opt}>{opt}</MenuItem>
+                                    <MenuItem key={"buildparamopt" + i} value={opt}>{choiceLabel(opt)}</MenuItem>
                                 ))
                             }
                             </Select>
@@ -851,7 +859,7 @@ export function CreatePayloadParameter({onChange, parameter_type, default_value,
                                                     >
                                                         {
                                                             choices.map((opt, i) => (
-                                                                <MenuItem key={name + i} value={opt}>{opt}</MenuItem>
+                                                                <MenuItem key={name + i} value={opt}>{choiceLabel(opt)}</MenuItem>
                                                             ))
                                                         }
                                                     </Select>

--- a/MythicReactUI/src/components/pages/CreatePayload/SchemaFormRenderer.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/SchemaFormRenderer.js
@@ -68,11 +68,11 @@ const CollapsibleSection = ({label, summary, description, defaultCollapsed, chil
 // A schema descriptor is a JSON object. Supported `type` values:
 //   object      { type: "object", fields: [ {name, type, label, description, show_when?, ...}, ... ] }
 //   array       { type: "array", items: <schema>, label }
-//   enum        { type: "enum", choices: [..], choiceLabels: {value: display}?, label }
+//   enum        { type: "enum", choices: [..], choices_display_names: {value: display}?, label }
 //   string      { type: "string", label, placeholder? }
 //   number      { type: "number", label }
 //   boolean     { type: "boolean", label }
-//   string_map  { type: "string_map", label, keyLabel?, valueLabel? }
+//   string_map  { type: "string_map", label, key_label?, value_label? }
 //
 // Conditional rendering: any field in an object's fields[] may carry
 //   show_when: {field: "<siblingName>", in: [<values>]}
@@ -306,8 +306,8 @@ const ArrayOfObjectField = ({schema, value, onChange, depth}) => {
 const StringMapField = ({schema, value, onChange}) => {
     const obj = (value && typeof value === "object" && !Array.isArray(value)) ? value : {};
     const entries = Object.entries(obj);
-    const keyLabel = schema.keyLabel || "Key";
-    const valueLabel = schema.valueLabel || "Value";
+    const keyLabel = schema.key_label || "Key";
+    const valueLabel = schema.value_label || "Value";
     const renameKey = (oldKey, newKey) => {
         if(newKey === oldKey) return;
         const next = {};
@@ -376,7 +376,7 @@ const StringMapField = ({schema, value, onChange}) => {
 
 const EnumField = ({schema, value, onChange}) => {
     const choices = schema.choices || [];
-    const labels = schema.choiceLabels || {};
+    const labels = schema.choices_display_names || {};
     return (
         <FormControl size="small" fullWidth style={{marginTop: "8px", marginBottom: "4px"}}>
             {schema.label && <InputLabel>{schema.label}</InputLabel>}

--- a/MythicReactUI/src/components/pages/CreatePayload/SchemaFormRenderer.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/SchemaFormRenderer.js
@@ -16,6 +16,54 @@ import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+
+const CollapsibleSection = ({label, summary, description, defaultCollapsed, children}) => {
+    const [collapsed, setCollapsed] = React.useState(!!defaultCollapsed);
+    return (
+        <div style={{marginTop: "12px", marginBottom: "8px"}}>
+            <div
+                role="button"
+                tabIndex={0}
+                aria-expanded={!collapsed}
+                onClick={() => setCollapsed(prev => !prev)}
+                onKeyDown={(e) => {
+                    if(e.key === "Enter" || e.key === " "){
+                        e.preventDefault();
+                        setCollapsed(prev => !prev);
+                    }
+                }}
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "2px",
+                    cursor: "pointer",
+                    userSelect: "none",
+                    marginBottom: "4px",
+                }}
+            >
+                {collapsed
+                    ? <ChevronRightIcon fontSize="small" style={{opacity: 0.7}} />
+                    : <ExpandMoreIcon fontSize="small" style={{opacity: 0.7}} />}
+                <Typography variant="subtitle2" style={{fontWeight: 600}}>
+                    {label}
+                </Typography>
+                {summary && (
+                    <Typography variant="caption" color="text.secondary" style={{marginLeft: "4px"}}>
+                        {summary}
+                    </Typography>
+                )}
+            </div>
+            {!collapsed && description && (
+                <Typography variant="caption" color="text.secondary" style={{display: "block", marginBottom: "6px", marginLeft: "22px"}}>
+                    {description}
+                </Typography>
+            )}
+            {!collapsed && children}
+        </div>
+    );
+};
 
 // A schema descriptor is a JSON object. Supported `type` values:
 //   object      { type: "object", fields: [ {name, type, label, description, show_when?, ...}, ... ] }
@@ -121,44 +169,35 @@ const ObjectField = ({schema, value, onChange, depth}) => {
         );
     }
 
-    return (
-        <div style={{marginTop: "12px", marginBottom: "8px"}}>
-            {schema.label && (
-                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "4px"}}>
-                    {schema.label}
-                </Typography>
-            )}
-            {schema.description && (
-                <Typography variant="caption" color="text.secondary" style={{display: "block", marginBottom: "6px"}}>
-                    {schema.description}
-                </Typography>
-            )}
-            <div style={{
-                borderLeft: "2px solid rgba(127,127,127,0.3)",
-                paddingLeft: "14px",
-                paddingRight: "4px",
-                paddingTop: "4px",
-                paddingBottom: "4px",
-                display: "flex",
-                flexDirection: "column",
-                gap: "6px",
-            }}>
-                {body}
-            </div>
+    const inner = (
+        <div style={{
+            borderLeft: "2px solid rgba(127,127,127,0.3)",
+            paddingLeft: "14px",
+            paddingRight: "4px",
+            paddingTop: "4px",
+            paddingBottom: "4px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "6px",
+        }}>
+            {body}
         </div>
     );
+    if(schema.label){
+        return (
+            <CollapsibleSection label={schema.label} description={schema.description}>
+                {inner}
+            </CollapsibleSection>
+        );
+    }
+    return <div style={{marginTop: "12px", marginBottom: "8px"}}>{inner}</div>;
 };
 
 const ArrayOfPrimitiveField = ({schema, value, onChange, depth}) => {
     const arr = Array.isArray(value) ? value : [];
     const itemSchema = schema.items || {type: "string"};
-    return (
-        <div style={{marginTop: "12px", marginBottom: "8px"}}>
-            {schema.label && (
-                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "6px"}}>
-                    {schema.label}
-                </Typography>
-            )}
+    const body = (
+        <React.Fragment>
             {arr.map((item, i) => (
                 <div key={i} style={{display: "flex", alignItems: "center", gap: "8px", marginBottom: "8px"}}>
                     <div style={{flexGrow: 1, minWidth: 0}}>
@@ -187,20 +226,25 @@ const ArrayOfPrimitiveField = ({schema, value, onChange, depth}) => {
                     onClick={() => onChange([...arr, emptyValueForSchema(itemSchema)])}>
                 Add
             </Button>
-        </div>
+        </React.Fragment>
     );
+    if(schema.label){
+        return (
+            <CollapsibleSection label={schema.label}
+                                summary={`(${arr.length})`}
+                                description={schema.description}>
+                {body}
+            </CollapsibleSection>
+        );
+    }
+    return <div style={{marginTop: "12px", marginBottom: "8px"}}>{body}</div>;
 };
 
 const ArrayOfObjectField = ({schema, value, onChange, depth}) => {
     const arr = Array.isArray(value) ? value : [];
     const itemSchema = schema.items;
-    return (
-        <div style={{marginTop: "12px", marginBottom: "8px"}}>
-            {schema.label && (
-                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "6px"}}>
-                    {schema.label}
-                </Typography>
-            )}
+    const body = (
+        <React.Fragment>
             {arr.map((item, i) => (
                 <Paper variant="outlined" key={i}
                        style={{
@@ -245,8 +289,18 @@ const ArrayOfObjectField = ({schema, value, onChange, depth}) => {
                     onClick={() => onChange([...arr, emptyValueForSchema(itemSchema)])}>
                 Add
             </Button>
-        </div>
+        </React.Fragment>
     );
+    if(schema.label){
+        return (
+            <CollapsibleSection label={schema.label}
+                                summary={`(${arr.length})`}
+                                description={schema.description}>
+                {body}
+            </CollapsibleSection>
+        );
+    }
+    return <div style={{marginTop: "12px", marginBottom: "8px"}}>{body}</div>;
 };
 
 const StringMapField = ({schema, value, onChange}) => {
@@ -276,13 +330,8 @@ const StringMapField = ({schema, value, onChange}) => {
         while(key in obj){ i++; key = `${base}_${i}`; }
         onChange({...obj, [key]: ""});
     };
-    return (
-        <div style={{marginTop: "12px", marginBottom: "8px"}}>
-            {schema.label && (
-                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "6px"}}>
-                    {schema.label}
-                </Typography>
-            )}
+    const body = (
+        <React.Fragment>
             {entries.length > 0 && (
                 <Table size="small">
                     <TableBody>
@@ -311,8 +360,18 @@ const StringMapField = ({schema, value, onChange}) => {
             <Button size="small" startIcon={<AddCircleIcon />} onClick={addEntry}>
                 Add entry
             </Button>
-        </div>
+        </React.Fragment>
     );
+    if(schema.label){
+        return (
+            <CollapsibleSection label={schema.label}
+                                summary={`(${entries.length})`}
+                                description={schema.description}>
+                {body}
+            </CollapsibleSection>
+        );
+    }
+    return <div style={{marginTop: "12px", marginBottom: "8px"}}>{body}</div>;
 };
 
 const EnumField = ({schema, value, onChange}) => {

--- a/MythicReactUI/src/components/pages/CreatePayload/SchemaFormRenderer.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/SchemaFormRenderer.js
@@ -1,0 +1,323 @@
+import React from 'react';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import TextField from '@mui/material/TextField';
+import Switch from '@mui/material/Switch';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import Button from '@mui/material/Button';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddCircleIcon from '@mui/icons-material/AddCircle';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableRow from '@mui/material/TableRow';
+import TableCell from '@mui/material/TableCell';
+
+// A schema descriptor is a JSON object. Supported `type` values:
+//   object      { type: "object", fields: [ {name, type, label, description, ...}, ... ] }
+//   array       { type: "array", items: <schema>, label }  (items is itself a schema)
+//   enum        { type: "enum", choices: [..], choiceLabels: {value: display}?, label }
+//   string      { type: "string", label, placeholder? }
+//   number      { type: "number", label }
+//   boolean     { type: "boolean", label }
+//   string_map  { type: "string_map", label, keyLabel?, valueLabel? }
+//
+// SchemaFormRenderer is controlled: pass `value` and `onChange`. It renders a
+// section for the top-level schema and recurses for nested composites.
+
+const emptyValueForSchema = (schema) => {
+    switch(schema?.type){
+        case "object": {
+            const out = {};
+            for(const f of (schema.fields || [])){
+                out[f.name] = emptyValueForSchema(f);
+            }
+            return out;
+        }
+        case "array":      return [];
+        case "enum":       return (schema.choices && schema.choices.length > 0) ? schema.choices[0] : "";
+        case "string":     return "";
+        case "number":     return 0;
+        case "boolean":    return false;
+        case "string_map": return {};
+        default:           return null;
+    }
+};
+
+// Only keep own enumerable properties and primitive/plain types on output.
+const cloneValue = (v) => {
+    if(v === null || v === undefined) return v;
+    if(Array.isArray(v)) return v.map(cloneValue);
+    if(typeof v === "object") {
+        const out = {};
+        for(const k of Object.keys(v)) out[k] = cloneValue(v[k]);
+        return out;
+    }
+    return v;
+};
+
+const ObjectField = ({schema, value, onChange}) => {
+    const safeValue = (value && typeof value === "object" && !Array.isArray(value)) ? value : {};
+    return (
+        <div style={{marginTop: "4px", marginBottom: "8px"}}>
+            {schema.label && (
+                <Typography variant="subtitle2" style={{fontWeight: 600, marginTop: "8px", marginBottom: "4px"}}>
+                    {schema.label}
+                </Typography>
+            )}
+            {schema.description && (
+                <Typography variant="caption" color="text.secondary" style={{display: "block", marginBottom: "4px"}}>
+                    {schema.description}
+                </Typography>
+            )}
+            <Paper variant="outlined" style={{padding: "8px 12px"}}>
+                {(schema.fields || []).map(fieldSchema => {
+                    const fieldValue = safeValue[fieldSchema.name];
+                    return (
+                        <SchemaFormRenderer
+                            key={fieldSchema.name}
+                            schema={fieldSchema}
+                            value={fieldValue === undefined ? emptyValueForSchema(fieldSchema) : fieldValue}
+                            onChange={(newFieldVal) => {
+                                onChange({...safeValue, [fieldSchema.name]: newFieldVal});
+                            }}
+                        />
+                    );
+                })}
+            </Paper>
+        </div>
+    );
+};
+
+const ArrayOfPrimitiveField = ({schema, value, onChange}) => {
+    const arr = Array.isArray(value) ? value : [];
+    const itemSchema = schema.items || {type: "string"};
+    return (
+        <div style={{marginTop: "4px", marginBottom: "8px"}}>
+            {schema.label && (
+                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "4px"}}>{schema.label}</Typography>
+            )}
+            {arr.map((item, i) => (
+                <div key={i} style={{display: "flex", alignItems: "center", gap: "4px", marginBottom: "4px"}}>
+                    <SchemaFormRenderer
+                        schema={{...itemSchema, label: undefined}}
+                        value={item}
+                        onChange={(newItem) => {
+                            const next = [...arr];
+                            next[i] = newItem;
+                            onChange(next);
+                        }}
+                    />
+                    <IconButton size="small" color="error" aria-label="remove"
+                                onClick={() => {
+                                    const next = [...arr];
+                                    next.splice(i, 1);
+                                    onChange(next);
+                                }}>
+                        <DeleteIcon fontSize="small" />
+                    </IconButton>
+                </div>
+            ))}
+            <Button size="small" startIcon={<AddCircleIcon />}
+                    onClick={() => onChange([...arr, emptyValueForSchema(itemSchema)])}>
+                Add
+            </Button>
+        </div>
+    );
+};
+
+const ArrayOfObjectField = ({schema, value, onChange}) => {
+    const arr = Array.isArray(value) ? value : [];
+    const itemSchema = schema.items;
+    return (
+        <div style={{marginTop: "4px", marginBottom: "8px"}}>
+            {schema.label && (
+                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "4px"}}>{schema.label}</Typography>
+            )}
+            {arr.map((item, i) => (
+                <Paper variant="outlined" key={i} style={{padding: "8px 12px", marginBottom: "6px", position: "relative"}}>
+                    <IconButton size="small" color="error" aria-label="remove"
+                                style={{position: "absolute", right: 4, top: 4}}
+                                onClick={() => {
+                                    const next = [...arr];
+                                    next.splice(i, 1);
+                                    onChange(next);
+                                }}>
+                        <DeleteIcon fontSize="small" />
+                    </IconButton>
+                    {(itemSchema.fields || []).map(fieldSchema => {
+                        const fv = (item || {})[fieldSchema.name];
+                        return (
+                            <SchemaFormRenderer
+                                key={fieldSchema.name}
+                                schema={fieldSchema}
+                                value={fv === undefined ? emptyValueForSchema(fieldSchema) : fv}
+                                onChange={(newVal) => {
+                                    const next = [...arr];
+                                    next[i] = {...(item || {}), [fieldSchema.name]: newVal};
+                                    onChange(next);
+                                }}
+                            />
+                        );
+                    })}
+                </Paper>
+            ))}
+            <Button size="small" startIcon={<AddCircleIcon />}
+                    onClick={() => onChange([...arr, emptyValueForSchema(itemSchema)])}>
+                Add
+            </Button>
+        </div>
+    );
+};
+
+const StringMapField = ({schema, value, onChange}) => {
+    const obj = (value && typeof value === "object" && !Array.isArray(value)) ? value : {};
+    const entries = Object.entries(obj);
+    const keyLabel = schema.keyLabel || "Key";
+    const valueLabel = schema.valueLabel || "Value";
+    const renameKey = (oldKey, newKey) => {
+        if(newKey === oldKey) return;
+        const next = {};
+        for(const [k, v] of entries){
+            if(k === oldKey){ next[newKey] = v; }
+            else { next[k] = v; }
+        }
+        onChange(next);
+    };
+    const setVal = (k, v) => {
+        onChange({...obj, [k]: v});
+    };
+    const removeKey = (k) => {
+        const next = {...obj};
+        delete next[k];
+        onChange(next);
+    };
+    const addEntry = () => {
+        // pick a unique empty key
+        let base = "new_key";
+        let i = 0;
+        let key = base;
+        while(key in obj){ i++; key = `${base}_${i}`; }
+        onChange({...obj, [key]: ""});
+    };
+    return (
+        <div style={{marginTop: "4px", marginBottom: "8px"}}>
+            {schema.label && (
+                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "4px"}}>{schema.label}</Typography>
+            )}
+            {entries.length > 0 && (
+                <Table size="small">
+                    <TableBody>
+                        {entries.map(([k, v]) => (
+                            <TableRow key={k}>
+                                <TableCell style={{width: "35%", padding: "4px"}}>
+                                    <TextField size="small" fullWidth label={keyLabel}
+                                               defaultValue={k}
+                                               onBlur={(e) => renameKey(k, e.target.value)} />
+                                </TableCell>
+                                <TableCell style={{padding: "4px"}}>
+                                    <TextField size="small" fullWidth label={valueLabel}
+                                               value={v}
+                                               onChange={(e) => setVal(k, e.target.value)} />
+                                </TableCell>
+                                <TableCell style={{width: "32px", padding: "4px"}}>
+                                    <IconButton size="small" color="error" onClick={() => removeKey(k)}>
+                                        <DeleteIcon fontSize="small" />
+                                    </IconButton>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            )}
+            <Button size="small" startIcon={<AddCircleIcon />} onClick={addEntry}>
+                Add entry
+            </Button>
+        </div>
+    );
+};
+
+const EnumField = ({schema, value, onChange}) => {
+    const choices = schema.choices || [];
+    const labels = schema.choiceLabels || {};
+    return (
+        <FormControl size="small" fullWidth style={{marginTop: "4px", marginBottom: "4px"}}>
+            {schema.label && <InputLabel>{schema.label}</InputLabel>}
+            <Select
+                value={value ?? ""}
+                label={schema.label}
+                onChange={(e) => onChange(e.target.value)}
+            >
+                {choices.map(c => (
+                    <MenuItem key={c} value={c}>{labels[c] || c}</MenuItem>
+                ))}
+            </Select>
+        </FormControl>
+    );
+};
+
+const StringField = ({schema, value, onChange}) => (
+    <TextField
+        size="small"
+        fullWidth
+        label={schema.label}
+        placeholder={schema.placeholder}
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value)}
+        style={{marginTop: "4px", marginBottom: "4px"}}
+    />
+);
+
+const NumberField = ({schema, value, onChange}) => (
+    <TextField
+        size="small"
+        fullWidth
+        type="number"
+        label={schema.label}
+        value={value ?? 0}
+        onChange={(e) => onChange(Number(e.target.value))}
+        style={{marginTop: "4px", marginBottom: "4px"}}
+    />
+);
+
+const BooleanField = ({schema, value, onChange}) => (
+    <FormControlLabel
+        label={schema.label || ""}
+        control={<Switch checked={!!value} onChange={(e) => onChange(e.target.checked)} />}
+    />
+);
+
+export function SchemaFormRenderer({schema, value, onChange}){
+    if(!schema) return null;
+    switch(schema.type){
+        case "object":
+            return <ObjectField schema={schema} value={value} onChange={onChange} />;
+        case "array":
+            if(schema.items?.type === "object"){
+                return <ArrayOfObjectField schema={schema} value={value} onChange={onChange} />;
+            }
+            return <ArrayOfPrimitiveField schema={schema} value={value} onChange={onChange} />;
+        case "enum":
+            return <EnumField schema={schema} value={value} onChange={onChange} />;
+        case "string":
+            return <StringField schema={schema} value={value} onChange={onChange} />;
+        case "number":
+            return <NumberField schema={schema} value={value} onChange={onChange} />;
+        case "boolean":
+            return <BooleanField schema={schema} value={value} onChange={onChange} />;
+        case "string_map":
+            return <StringMapField schema={schema} value={value} onChange={onChange} />;
+        default:
+            return (
+                <Typography variant="caption" color="text.secondary">
+                    Unknown schema type: {String(schema?.type)}
+                </Typography>
+            );
+    }
+}
+
+export {emptyValueForSchema, cloneValue};

--- a/MythicReactUI/src/components/pages/CreatePayload/SchemaFormRenderer.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/SchemaFormRenderer.js
@@ -18,16 +18,21 @@ import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 
 // A schema descriptor is a JSON object. Supported `type` values:
-//   object      { type: "object", fields: [ {name, type, label, description, ...}, ... ] }
-//   array       { type: "array", items: <schema>, label }  (items is itself a schema)
+//   object      { type: "object", fields: [ {name, type, label, description, show_when?, ...}, ... ] }
+//   array       { type: "array", items: <schema>, label }
 //   enum        { type: "enum", choices: [..], choiceLabels: {value: display}?, label }
 //   string      { type: "string", label, placeholder? }
 //   number      { type: "number", label }
 //   boolean     { type: "boolean", label }
 //   string_map  { type: "string_map", label, keyLabel?, valueLabel? }
 //
-// SchemaFormRenderer is controlled: pass `value` and `onChange`. It renders a
-// section for the top-level schema and recurses for nested composites.
+// Conditional rendering: any field in an object's fields[] may carry
+//   show_when: {field: "<siblingName>", in: [<values>]}
+// and it will only be rendered when the sibling's current value is in the list.
+//
+// SchemaFormRenderer is controlled: pass `value` and `onChange`. The top-level
+// call renders without a surrounding Paper; nested objects get a subtle left-
+// border accent instead of stacking Paper inside Paper.
 
 const emptyValueForSchema = (schema) => {
     switch(schema?.type){
@@ -48,7 +53,6 @@ const emptyValueForSchema = (schema) => {
     }
 };
 
-// Only keep own enumerable properties and primitive/plain types on output.
 const cloneValue = (v) => {
     if(v === null || v === undefined) return v;
     if(Array.isArray(v)) return v.map(cloneValue);
@@ -60,58 +64,102 @@ const cloneValue = (v) => {
     return v;
 };
 
-const ObjectField = ({schema, value, onChange}) => {
+const shouldShow = (fieldSchema, parentValue) => {
+    const sw = fieldSchema?.show_when;
+    if(!sw || !sw.field || !Array.isArray(sw.in)) return true;
+    return sw.in.includes(parentValue?.[sw.field]);
+};
+
+const ObjectField = ({schema, value, onChange, depth}) => {
     const safeValue = (value && typeof value === "object" && !Array.isArray(value)) ? value : {};
+    const body = (
+        <React.Fragment>
+            {(schema.fields || []).map(fieldSchema => {
+                if(!shouldShow(fieldSchema, safeValue)) return null;
+                const fieldValue = safeValue[fieldSchema.name];
+                return (
+                    <SchemaFormRenderer
+                        key={fieldSchema.name}
+                        schema={fieldSchema}
+                        value={fieldValue === undefined ? emptyValueForSchema(fieldSchema) : fieldValue}
+                        depth={(depth || 0) + 1}
+                        onChange={(newFieldVal) => {
+                            onChange({...safeValue, [fieldSchema.name]: newFieldVal});
+                        }}
+                    />
+                );
+            })}
+        </React.Fragment>
+    );
+
+    // Top-level object gets no wrapper — content flows in the modal's natural
+    // padding. Nested objects get a soft left-border accent and generous
+    // interior padding.
+    if(!depth || depth === 0){
+        return (
+            <div style={{display: "flex", flexDirection: "column", gap: "12px"}}>
+                {schema.label && (
+                    <Typography variant="subtitle1" style={{fontWeight: 700, letterSpacing: "0.3px"}}>
+                        {schema.label}
+                    </Typography>
+                )}
+                {body}
+            </div>
+        );
+    }
+
     return (
-        <div style={{marginTop: "4px", marginBottom: "8px"}}>
+        <div style={{marginTop: "12px", marginBottom: "8px"}}>
             {schema.label && (
-                <Typography variant="subtitle2" style={{fontWeight: 600, marginTop: "8px", marginBottom: "4px"}}>
+                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "4px"}}>
                     {schema.label}
                 </Typography>
             )}
             {schema.description && (
-                <Typography variant="caption" color="text.secondary" style={{display: "block", marginBottom: "4px"}}>
+                <Typography variant="caption" color="text.secondary" style={{display: "block", marginBottom: "6px"}}>
                     {schema.description}
                 </Typography>
             )}
-            <Paper variant="outlined" style={{padding: "8px 12px"}}>
-                {(schema.fields || []).map(fieldSchema => {
-                    const fieldValue = safeValue[fieldSchema.name];
-                    return (
-                        <SchemaFormRenderer
-                            key={fieldSchema.name}
-                            schema={fieldSchema}
-                            value={fieldValue === undefined ? emptyValueForSchema(fieldSchema) : fieldValue}
-                            onChange={(newFieldVal) => {
-                                onChange({...safeValue, [fieldSchema.name]: newFieldVal});
-                            }}
-                        />
-                    );
-                })}
-            </Paper>
+            <div style={{
+                borderLeft: "2px solid rgba(127,127,127,0.3)",
+                paddingLeft: "14px",
+                paddingRight: "4px",
+                paddingTop: "4px",
+                paddingBottom: "4px",
+                display: "flex",
+                flexDirection: "column",
+                gap: "6px",
+            }}>
+                {body}
+            </div>
         </div>
     );
 };
 
-const ArrayOfPrimitiveField = ({schema, value, onChange}) => {
+const ArrayOfPrimitiveField = ({schema, value, onChange, depth}) => {
     const arr = Array.isArray(value) ? value : [];
     const itemSchema = schema.items || {type: "string"};
     return (
-        <div style={{marginTop: "4px", marginBottom: "8px"}}>
+        <div style={{marginTop: "12px", marginBottom: "8px"}}>
             {schema.label && (
-                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "4px"}}>{schema.label}</Typography>
+                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "6px"}}>
+                    {schema.label}
+                </Typography>
             )}
             {arr.map((item, i) => (
-                <div key={i} style={{display: "flex", alignItems: "center", gap: "4px", marginBottom: "4px"}}>
-                    <SchemaFormRenderer
-                        schema={{...itemSchema, label: undefined}}
-                        value={item}
-                        onChange={(newItem) => {
-                            const next = [...arr];
-                            next[i] = newItem;
-                            onChange(next);
-                        }}
-                    />
+                <div key={i} style={{display: "flex", alignItems: "center", gap: "8px", marginBottom: "8px"}}>
+                    <div style={{flexGrow: 1, minWidth: 0}}>
+                        <SchemaFormRenderer
+                            schema={{...itemSchema, label: undefined}}
+                            value={item}
+                            depth={(depth || 0) + 1}
+                            onChange={(newItem) => {
+                                const next = [...arr];
+                                next[i] = newItem;
+                                onChange(next);
+                            }}
+                        />
+                    </div>
                     <IconButton size="small" color="error" aria-label="remove"
                                 onClick={() => {
                                     const next = [...arr];
@@ -130,18 +178,46 @@ const ArrayOfPrimitiveField = ({schema, value, onChange}) => {
     );
 };
 
-const ArrayOfObjectField = ({schema, value, onChange}) => {
+const ArrayOfObjectField = ({schema, value, onChange, depth}) => {
     const arr = Array.isArray(value) ? value : [];
     const itemSchema = schema.items;
     return (
-        <div style={{marginTop: "4px", marginBottom: "8px"}}>
+        <div style={{marginTop: "12px", marginBottom: "8px"}}>
             {schema.label && (
-                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "4px"}}>{schema.label}</Typography>
+                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "6px"}}>
+                    {schema.label}
+                </Typography>
             )}
             {arr.map((item, i) => (
-                <Paper variant="outlined" key={i} style={{padding: "8px 12px", marginBottom: "6px", position: "relative"}}>
+                <Paper variant="outlined" key={i}
+                       style={{
+                           padding: "12px 14px",
+                           marginBottom: "10px",
+                           display: "flex",
+                           gap: "10px",
+                           alignItems: "flex-start",
+                       }}>
+                    <div style={{flexGrow: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: "6px"}}>
+                        {(itemSchema.fields || []).map(fieldSchema => {
+                            if(!shouldShow(fieldSchema, item)) return null;
+                            const fv = (item || {})[fieldSchema.name];
+                            return (
+                                <SchemaFormRenderer
+                                    key={fieldSchema.name}
+                                    schema={fieldSchema}
+                                    value={fv === undefined ? emptyValueForSchema(fieldSchema) : fv}
+                                    depth={(depth || 0) + 1}
+                                    onChange={(newVal) => {
+                                        const next = [...arr];
+                                        next[i] = {...(item || {}), [fieldSchema.name]: newVal};
+                                        onChange(next);
+                                    }}
+                                />
+                            );
+                        })}
+                    </div>
                     <IconButton size="small" color="error" aria-label="remove"
-                                style={{position: "absolute", right: 4, top: 4}}
+                                style={{marginTop: "4px"}}
                                 onClick={() => {
                                     const next = [...arr];
                                     next.splice(i, 1);
@@ -149,21 +225,6 @@ const ArrayOfObjectField = ({schema, value, onChange}) => {
                                 }}>
                         <DeleteIcon fontSize="small" />
                     </IconButton>
-                    {(itemSchema.fields || []).map(fieldSchema => {
-                        const fv = (item || {})[fieldSchema.name];
-                        return (
-                            <SchemaFormRenderer
-                                key={fieldSchema.name}
-                                schema={fieldSchema}
-                                value={fv === undefined ? emptyValueForSchema(fieldSchema) : fv}
-                                onChange={(newVal) => {
-                                    const next = [...arr];
-                                    next[i] = {...(item || {}), [fieldSchema.name]: newVal};
-                                    onChange(next);
-                                }}
-                            />
-                        );
-                    })}
                 </Paper>
             ))}
             <Button size="small" startIcon={<AddCircleIcon />}
@@ -188,16 +249,13 @@ const StringMapField = ({schema, value, onChange}) => {
         }
         onChange(next);
     };
-    const setVal = (k, v) => {
-        onChange({...obj, [k]: v});
-    };
+    const setVal = (k, v) => { onChange({...obj, [k]: v}); };
     const removeKey = (k) => {
         const next = {...obj};
         delete next[k];
         onChange(next);
     };
     const addEntry = () => {
-        // pick a unique empty key
         let base = "new_key";
         let i = 0;
         let key = base;
@@ -205,26 +263,28 @@ const StringMapField = ({schema, value, onChange}) => {
         onChange({...obj, [key]: ""});
     };
     return (
-        <div style={{marginTop: "4px", marginBottom: "8px"}}>
+        <div style={{marginTop: "12px", marginBottom: "8px"}}>
             {schema.label && (
-                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "4px"}}>{schema.label}</Typography>
+                <Typography variant="subtitle2" style={{fontWeight: 600, marginBottom: "6px"}}>
+                    {schema.label}
+                </Typography>
             )}
             {entries.length > 0 && (
                 <Table size="small">
                     <TableBody>
                         {entries.map(([k, v]) => (
                             <TableRow key={k}>
-                                <TableCell style={{width: "35%", padding: "4px"}}>
+                                <TableCell style={{width: "35%", padding: "6px 8px", borderBottom: "none"}}>
                                     <TextField size="small" fullWidth label={keyLabel}
                                                defaultValue={k}
                                                onBlur={(e) => renameKey(k, e.target.value)} />
                                 </TableCell>
-                                <TableCell style={{padding: "4px"}}>
+                                <TableCell style={{padding: "6px 8px", borderBottom: "none"}}>
                                     <TextField size="small" fullWidth label={valueLabel}
                                                value={v}
                                                onChange={(e) => setVal(k, e.target.value)} />
                                 </TableCell>
-                                <TableCell style={{width: "32px", padding: "4px"}}>
+                                <TableCell style={{width: "40px", padding: "6px 0px", borderBottom: "none"}}>
                                     <IconButton size="small" color="error" onClick={() => removeKey(k)}>
                                         <DeleteIcon fontSize="small" />
                                     </IconButton>
@@ -245,7 +305,7 @@ const EnumField = ({schema, value, onChange}) => {
     const choices = schema.choices || [];
     const labels = schema.choiceLabels || {};
     return (
-        <FormControl size="small" fullWidth style={{marginTop: "4px", marginBottom: "4px"}}>
+        <FormControl size="small" fullWidth style={{marginTop: "8px", marginBottom: "4px"}}>
             {schema.label && <InputLabel>{schema.label}</InputLabel>}
             <Select
                 value={value ?? ""}
@@ -256,51 +316,75 @@ const EnumField = ({schema, value, onChange}) => {
                     <MenuItem key={c} value={c}>{labels[c] || c}</MenuItem>
                 ))}
             </Select>
+            {schema.description && (
+                <Typography variant="caption" color="text.secondary" style={{marginTop: "4px"}}>
+                    {schema.description}
+                </Typography>
+            )}
         </FormControl>
     );
 };
 
 const StringField = ({schema, value, onChange}) => (
-    <TextField
-        size="small"
-        fullWidth
-        label={schema.label}
-        placeholder={schema.placeholder}
-        value={value ?? ""}
-        onChange={(e) => onChange(e.target.value)}
-        style={{marginTop: "4px", marginBottom: "4px"}}
-    />
+    <div style={{marginTop: "8px", marginBottom: "4px"}}>
+        <TextField
+            size="small"
+            fullWidth
+            label={schema.label}
+            placeholder={schema.placeholder}
+            value={value ?? ""}
+            onChange={(e) => onChange(e.target.value)}
+        />
+        {schema.description && (
+            <Typography variant="caption" color="text.secondary" style={{display: "block", marginTop: "4px"}}>
+                {schema.description}
+            </Typography>
+        )}
+    </div>
 );
 
 const NumberField = ({schema, value, onChange}) => (
-    <TextField
-        size="small"
-        fullWidth
-        type="number"
-        label={schema.label}
-        value={value ?? 0}
-        onChange={(e) => onChange(Number(e.target.value))}
-        style={{marginTop: "4px", marginBottom: "4px"}}
-    />
+    <div style={{marginTop: "8px", marginBottom: "4px"}}>
+        <TextField
+            size="small"
+            fullWidth
+            type="number"
+            label={schema.label}
+            value={value ?? 0}
+            onChange={(e) => onChange(Number(e.target.value))}
+        />
+        {schema.description && (
+            <Typography variant="caption" color="text.secondary" style={{display: "block", marginTop: "4px"}}>
+                {schema.description}
+            </Typography>
+        )}
+    </div>
 );
 
 const BooleanField = ({schema, value, onChange}) => (
-    <FormControlLabel
-        label={schema.label || ""}
-        control={<Switch checked={!!value} onChange={(e) => onChange(e.target.checked)} />}
-    />
+    <div style={{marginTop: "8px", marginBottom: "4px"}}>
+        <FormControlLabel
+            label={schema.label || ""}
+            control={<Switch checked={!!value} onChange={(e) => onChange(e.target.checked)} />}
+        />
+        {schema.description && (
+            <Typography variant="caption" color="text.secondary" style={{display: "block"}}>
+                {schema.description}
+            </Typography>
+        )}
+    </div>
 );
 
-export function SchemaFormRenderer({schema, value, onChange}){
+export function SchemaFormRenderer({schema, value, onChange, depth}){
     if(!schema) return null;
     switch(schema.type){
         case "object":
-            return <ObjectField schema={schema} value={value} onChange={onChange} />;
+            return <ObjectField schema={schema} value={value} onChange={onChange} depth={depth} />;
         case "array":
             if(schema.items?.type === "object"){
-                return <ArrayOfObjectField schema={schema} value={value} onChange={onChange} />;
+                return <ArrayOfObjectField schema={schema} value={value} onChange={onChange} depth={depth} />;
             }
-            return <ArrayOfPrimitiveField schema={schema} value={value} onChange={onChange} />;
+            return <ArrayOfPrimitiveField schema={schema} value={value} onChange={onChange} depth={depth} />;
         case "enum":
             return <EnumField schema={schema} value={value} onChange={onChange} />;
         case "string":

--- a/MythicReactUI/src/components/pages/CreatePayload/SchemaFormRenderer.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/SchemaFormRenderer.js
@@ -70,17 +70,30 @@ const shouldShow = (fieldSchema, parentValue) => {
     return sw.in.includes(parentValue?.[sw.field]);
 };
 
+// Resolves schema.placeholder based on a sibling's current value:
+//   placeholder_when: {field: "action", map: {xor: "key", prepend: "text"}}
+// Returns the original schema if no match or feature not present.
+const resolveConditionalPlaceholder = (fieldSchema, parentValue) => {
+    const pw = fieldSchema?.placeholder_when;
+    if(!pw || !pw.field || !pw.map || typeof pw.map !== "object") return fieldSchema;
+    const siblingVal = parentValue?.[pw.field];
+    const hint = pw.map[siblingVal];
+    if(typeof hint !== "string" || hint.length === 0) return fieldSchema;
+    return {...fieldSchema, placeholder: hint};
+};
+
 const ObjectField = ({schema, value, onChange, depth}) => {
     const safeValue = (value && typeof value === "object" && !Array.isArray(value)) ? value : {};
     const body = (
         <React.Fragment>
             {(schema.fields || []).map(fieldSchema => {
                 if(!shouldShow(fieldSchema, safeValue)) return null;
+                const resolved = resolveConditionalPlaceholder(fieldSchema, safeValue);
                 const fieldValue = safeValue[fieldSchema.name];
                 return (
                     <SchemaFormRenderer
                         key={fieldSchema.name}
-                        schema={fieldSchema}
+                        schema={resolved}
                         value={fieldValue === undefined ? emptyValueForSchema(fieldSchema) : fieldValue}
                         depth={(depth || 0) + 1}
                         onChange={(newFieldVal) => {
@@ -200,11 +213,12 @@ const ArrayOfObjectField = ({schema, value, onChange, depth}) => {
                     <div style={{flexGrow: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: "6px"}}>
                         {(itemSchema.fields || []).map(fieldSchema => {
                             if(!shouldShow(fieldSchema, item)) return null;
+                            const resolved = resolveConditionalPlaceholder(fieldSchema, item);
                             const fv = (item || {})[fieldSchema.name];
                             return (
                                 <SchemaFormRenderer
                                     key={fieldSchema.name}
-                                    schema={fieldSchema}
+                                    schema={resolved}
                                     value={fv === undefined ? emptyValueForSchema(fieldSchema) : fv}
                                     depth={(depth || 0) + 1}
                                     onChange={(newVal) => {

--- a/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
@@ -733,7 +733,29 @@ export const GetGroupedParameters = ({buildParameters, os, c2_name}) => {
     });
     if(c2_name){
         buildParameters.sort(sortByUiPositionThenName);
-        return [{name: c2_name, parameters: buildParameters}];
+        // If no parameter in this c2 profile has a group_name set, keep the
+        // legacy behavior: a single bucket labeled with the c2 profile name.
+        const hasAnyGroup = buildParameters.some(p => p?.group_name && p.group_name.length > 0);
+        if(!hasAnyGroup){
+            return [{name: c2_name, parameters: buildParameters}];
+        }
+        // Otherwise honor group_name. Scope the group label with the c2
+        // profile name so multiple included profiles don't collide when
+        // they share a group name (e.g. both defining a "Callbacks" group).
+        const byGroup = {};
+        const order = [];
+        for(const p of buildParameters){
+            const g = (p?.group_name && p.group_name.length > 0) ? p.group_name : "Other";
+            if(!(g in byGroup)){
+                byGroup[g] = [];
+                order.push(g);
+            }
+            byGroup[g].push(p);
+        }
+        return order.map(g => ({
+            name: `${c2_name} · ${g}`,
+            parameters: byGroup[g],
+        }));
     }
     for(let i = 0; i < buildParameters.length; i++){
         for(let j = 0; j < groupedData.length; j++){

--- a/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
@@ -842,16 +842,12 @@ export const GetGroupedParameters = ({buildParameters, os, c2_name}) => {
     //groupedData.sort((a,b) => -b.name.localeCompare(a.name));
     return groupedData;
 }
-const isParamModifiedFromDefault = (p) => {
-    // Date defaults are computed relative to "now" and don't have a
-    // static baseline to compare against, so suppress the indicator.
-    if(p?.parameter_type === "Date") return false;
-    // File defaults are opaque upload references, also skip.
-    if(p?.parameter_type === "File" || p?.parameter_type === "FileMultiple") return false;
-    // Compare tracked vs initial — both are the parsed component-native
-    // type populated from the same source, so JSON.stringify gives a
-    // reliable deep-equality check. default_value stays as the raw DB
-    // string and doesn't round-trip safely for arrays/objects.
+const hasParamChangedSinceLoad = (p) => {
+    // "Changed" == different from what was auto-populated when the
+    // operator landed on this page (either the c2 profile's default
+    // or, in edit flows, the previously-saved value). Works uniformly
+    // across parameter types because trackedValue and initialValue are
+    // both stored in the same component-native shape.
     const tracked = p?.trackedValue;
     const initial = p?.initialValue;
     if(tracked === undefined) return false;
@@ -875,12 +871,12 @@ export const ConfigurationSummary = ({buildParameters, os, c2_name}) => {
                 }
                 {b?.parameters?.map( (p) => {
                     const displayLabel = (p.display_name && p.display_name.length > 0) ? p.display_name : p.name;
-                    const modified = isParamModifiedFromDefault(p);
+                    const changed = hasParamChangedSinceLoad(p);
                     return (
                     <div className="mythic-create-summary-row" key={p.name}>
                         <Typography component="div" className="mythic-create-summary-name" style={{display: "flex", alignItems: "center", gap: "0.35rem"}}>
-                            {modified && (
-                                <span title="Modified from default"
+                            {changed && (
+                                <span title="Changed since load"
                                       style={{display: "inline-block", width: 8, height: 8, borderRadius: "50%", backgroundColor: theme.palette.warning.main, flexShrink: 0}} />
                             )}
                             {displayLabel}

--- a/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
@@ -152,6 +152,7 @@ query getPayloadTypesBuildParametersQuery($payload_id: Int!) {
           required
           verifier_regex
           choices
+          choices_display_names
           ui_position
           c2profile {
               name

--- a/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
@@ -843,13 +843,20 @@ export const GetGroupedParameters = ({buildParameters, os, c2_name}) => {
     return groupedData;
 }
 const isParamModifiedFromDefault = (p) => {
-    const tracked = p?.trackedValue !== undefined ? p.trackedValue : p?.value;
-    const def = p?.default_value;
-    if(tracked === undefined || tracked === null) return false;
-    if(Array.isArray(tracked) || typeof tracked === "object"){
-        try { return JSON.stringify(tracked) !== JSON.stringify(def); } catch(_) { return false; }
-    }
-    return String(tracked) !== String(def ?? "");
+    // Date defaults are computed relative to "now" and don't have a
+    // static baseline to compare against, so suppress the indicator.
+    if(p?.parameter_type === "Date") return false;
+    // File defaults are opaque upload references, also skip.
+    if(p?.parameter_type === "File" || p?.parameter_type === "FileMultiple") return false;
+    // Compare tracked vs initial — both are the parsed component-native
+    // type populated from the same source, so JSON.stringify gives a
+    // reliable deep-equality check. default_value stays as the raw DB
+    // string and doesn't round-trip safely for arrays/objects.
+    const tracked = p?.trackedValue;
+    const initial = p?.initialValue;
+    if(tracked === undefined) return false;
+    try { return JSON.stringify(tracked) !== JSON.stringify(initial); }
+    catch(_) { return false; }
 }
 export const ConfigurationSummary = ({buildParameters, os, c2_name}) => {
     const theme = useTheme();

--- a/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
@@ -144,6 +144,7 @@ query getPayloadTypesBuildParametersQuery($payload_id: Int!) {
           description
           display_name
           format_string
+          group_name
           id
           name
           parameter_type

--- a/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
@@ -141,6 +141,7 @@ query getPayloadTypesBuildParametersQuery($payload_id: Int!) {
         c2profileparameter {
           default_value
           description
+          display_name
           format_string
           id
           name

--- a/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
@@ -754,7 +754,7 @@ export const GetGroupedParameters = ({buildParameters, os, c2_name}) => {
             byGroup[g].push(p);
         }
         return order.map(g => ({
-            name: `${c2_name} · ${g}`,
+            name: g,
             parameters: byGroup[g],
         }));
     }

--- a/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
@@ -16,6 +16,7 @@ import {ParseForDisplay} from "../Payloads/DetailedPayloadTable";
 import {getModifiedC2Params} from "./Step4C2Profiles";
 import { Backdrop } from '@mui/material';
 import {MythicLoadingState} from "../../MythicComponents/MythicStateDisplay";
+import {useTheme} from '@mui/material/styles';
 
 
 const GET_Payload_Types = gql`
@@ -841,7 +842,17 @@ export const GetGroupedParameters = ({buildParameters, os, c2_name}) => {
     //groupedData.sort((a,b) => -b.name.localeCompare(a.name));
     return groupedData;
 }
+const isParamModifiedFromDefault = (p) => {
+    const tracked = p?.trackedValue !== undefined ? p.trackedValue : p?.value;
+    const def = p?.default_value;
+    if(tracked === undefined || tracked === null) return false;
+    if(Array.isArray(tracked) || typeof tracked === "object"){
+        try { return JSON.stringify(tracked) !== JSON.stringify(def); } catch(_) { return false; }
+    }
+    return String(tracked) !== String(def ?? "");
+}
 export const ConfigurationSummary = ({buildParameters, os, c2_name}) => {
+    const theme = useTheme();
     const [groupedParameters, setGroupedParameters] = React.useState([]);
     React.useEffect( () => {
         // grouped should be array of groupName
@@ -855,16 +866,24 @@ export const ConfigurationSummary = ({buildParameters, os, c2_name}) => {
                         {b.name}
                     </div>
                 }
-                {b?.parameters?.map( (p) => (
+                {b?.parameters?.map( (p) => {
+                    const displayLabel = (p.display_name && p.display_name.length > 0) ? p.display_name : p.name;
+                    const modified = isParamModifiedFromDefault(p);
+                    return (
                     <div className="mythic-create-summary-row" key={p.name}>
-                        <Typography component="div" className="mythic-create-summary-name">
-                            {p.name}
+                        <Typography component="div" className="mythic-create-summary-name" style={{display: "flex", alignItems: "center", gap: "0.35rem"}}>
+                            {modified && (
+                                <span title="Modified from default"
+                                      style={{display: "inline-block", width: 8, height: 8, borderRadius: "50%", backgroundColor: theme.palette.warning.main, flexShrink: 0}} />
+                            )}
+                            {displayLabel}
                         </Typography>
                         <div className="mythic-create-summary-value">
                             <ParseForDisplay cmd={p} />
                         </div>
                     </div>
-                ))}
+                    );
+                })}
             </div>
         ))
     )

--- a/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
@@ -156,6 +156,7 @@ query getPayloadTypesBuildParametersQuery($payload_id: Int!) {
           verifier_regex
           choices
           choices_display_names
+          form_schema
           ui_position
           c2profile {
               name

--- a/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step1SelectOS.js
@@ -10,6 +10,9 @@ import {useMythicLazyQuery} from "../../utilities/useMythicLazyQuery";
 import {PayloadSelect} from "../CreateWrapper/Step3SelectPayload";
 import {MythicAgentSVGIcon} from "../../MythicComponents/MythicAgentSVGIcon";
 import AddCircleIcon from '@mui/icons-material/AddCircle';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import IconButton from '@mui/material/IconButton';
 import {getDefaultChoices, getDefaultValueForType, getSavedToType} from "./Step2SelectPayloadType";
 import {CreatePayloadBuildParametersTable} from "./CreatePayloadBuildParametersTable";
 import {ParseForDisplay} from "../Payloads/DetailedPayloadTable";
@@ -585,6 +588,7 @@ export const ConfigureBuildParameters = (
 ) => {
     const [payloadTypeConfigPieces, setPayloadTypeConfigPieces] = React.useState({});
     const [payloadTypeParameters, setSelectedPayloadTypeParameters] = React.useState([]);
+    const [summaryCollapsed, setSummaryCollapsed] = React.useState(false);
     const getPayloadTypeBuildParameters = useMythicLazyQuery(GetBuildParametersQuery, {fetchPolicy: "network-only"});
     const onChange = (name, value, error) => {
         const newParams = payloadTypeParameters.map( (param) => {
@@ -687,12 +691,43 @@ export const ConfigureBuildParameters = (
                     </Typography>
                 </div>
             </div>
-            <div className="mythic-create-builder-split">
-                <section className="mythic-create-section mythic-create-section-scroll">
-                    <Typography component="div" className="mythic-create-section-title" style={{textAlign: "center"}}>
-                        Configuration Summary
-                    </Typography>
-                    <ConfigurationSummary buildParameters={payloadTypeParameters} os={os} />
+            <div className="mythic-create-builder-split" style={summaryCollapsed ? {gridTemplateColumns: "3rem minmax(0, 1fr)"} : undefined}>
+                <section
+                    className="mythic-create-section mythic-create-section-scroll"
+                    style={summaryCollapsed ? {alignItems: "center", cursor: "pointer", paddingLeft: "0.25rem", paddingRight: "0.25rem"} : undefined}
+                    onClick={summaryCollapsed ? () => setSummaryCollapsed(false) : undefined}
+                >
+                    <div style={{display: "flex", alignItems: "center", justifyContent: summaryCollapsed ? "center" : "space-between", gap: "0.5rem"}}>
+                        {!summaryCollapsed && (
+                            <Typography component="div" className="mythic-create-section-title" style={{textAlign: "center", flexGrow: 1}}>
+                                Configuration Summary
+                            </Typography>
+                        )}
+                        <IconButton size="small"
+                                    aria-label={summaryCollapsed ? "Expand configuration summary" : "Collapse configuration summary"}
+                                    title={summaryCollapsed ? "Expand" : "Collapse"}
+                                    onClick={(e) => { e.stopPropagation(); setSummaryCollapsed(prev => !prev); }}>
+                            {summaryCollapsed ? <ChevronRightIcon fontSize="small" /> : <ChevronLeftIcon fontSize="small" />}
+                        </IconButton>
+                    </div>
+                    {summaryCollapsed && (
+                        <div style={{flexGrow: 1, display: "flex", alignItems: "center", justifyContent: "center", userSelect: "none"}}>
+                            <Typography variant={"body2"} style={{
+                                fontWeight: 600,
+                                writingMode: "vertical-rl",
+                                transform: "rotate(180deg)",
+                                letterSpacing: 0,
+                                textTransform: "uppercase",
+                                fontSize: "0.75rem",
+                                opacity: 0.75,
+                            }}>
+                                Configuration Summary
+                            </Typography>
+                        </div>
+                    )}
+                    {!summaryCollapsed && (
+                        <ConfigurationSummary buildParameters={payloadTypeParameters} os={os} />
+                    )}
                 </section>
                 <section className="mythic-create-section mythic-create-section-scroll">
                     <CreatePayloadBuildParametersTable onChange={onChange} buildParameters={payloadTypeParameters} os={os}

--- a/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
@@ -16,6 +16,9 @@ import {CreatePayloadBuildParametersTable} from "./CreatePayloadBuildParametersT
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import CloseIcon from '@mui/icons-material/Close';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import IconButton from '@mui/material/IconButton';
 import {useMythicLazyQuery} from "../../utilities/useMythicLazyQuery";
 import {ConfigurationSummary} from "./Step1SelectOS";
 
@@ -151,6 +154,7 @@ export function Step4C2Profiles(props){
     const [selectedC2, setSelectedC2] = React.useState("None");
     const [includedC2Profiles, setIncludedC2Profiles] = React.useState([]);
     const [c2Profiles, setC2Profiles] = React.useState([]);
+    const [summaryCollapsed, setSummaryCollapsed] = React.useState(false);
     useQuery(GET_Payload_Types, {variables:{payloadType: props.buildOptions["payload_type"], operation_id: me?.user?.current_operation_id || 0},
         onCompleted: data => {
             const profiles = data.c2profile.map( (c2) => {
@@ -445,12 +449,21 @@ export function Step4C2Profiles(props){
                             </Typography>
                         </div>
                     </div>
-                    <div className="mythic-create-builder-split">
-                        <section className="mythic-create-section mythic-create-section-scroll">
-                            <Typography component="div" className="mythic-create-section-title" style={{textAlign: "center"}}>
-                                Configuration Summary
-                            </Typography>
-                            {includedC2Profiles.map( (c, index) => (
+                    <div className="mythic-create-builder-split" style={summaryCollapsed ? {gridTemplateColumns: "3rem minmax(0, 1fr)"} : undefined}>
+                        <section className="mythic-create-section mythic-create-section-scroll" style={summaryCollapsed ? {alignItems: "center", paddingLeft: "0.25rem", paddingRight: "0.25rem"} : undefined}>
+                            <div style={{display: "flex", alignItems: "center", justifyContent: summaryCollapsed ? "center" : "space-between", gap: "0.5rem"}}>
+                                {!summaryCollapsed && (
+                                    <Typography component="div" className="mythic-create-section-title" style={{textAlign: "center", flexGrow: 1}}>
+                                        Configuration Summary
+                                    </Typography>
+                                )}
+                                <IconButton size="small"
+                                            aria-label={summaryCollapsed ? "Expand configuration summary" : "Collapse configuration summary"}
+                                            onClick={() => setSummaryCollapsed(prev => !prev)}>
+                                    {summaryCollapsed ? <ChevronRightIcon fontSize="small" /> : <ChevronLeftIcon fontSize="small" />}
+                                </IconButton>
+                            </div>
+                            {!summaryCollapsed && includedC2Profiles.map( (c, index) => (
                                 <ConfigurationSummary key={c.name + index} buildParameters={c.c2profileparameters}
                                                       os={props.buildOptions.os} c2_name={c.name} />
                             ))}

--- a/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
@@ -31,6 +31,7 @@ query getPayloadTypesC2ProfilesQuery($payloadType: String!, $operation_id: Int!)
     c2profileparameters(where: {deleted: {_eq: false}}) {
       default_value
       description
+      display_name
       format_string
       id
       name
@@ -54,6 +55,7 @@ query getProfileInstanceQuery($name: String!, $operation_id: Int!, $c2_profile_i
     c2profileparameter {
       default_value
       description
+      display_name
       format_string
       id
       name
@@ -80,6 +82,7 @@ query getDefaultC2ProfileParameters($c2profile_id: Int!) {
       c2profileparameters(where: {deleted: {_eq: false}}) {
         default_value
         description
+        display_name
         format_string
         id
         name

--- a/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
@@ -35,6 +35,7 @@ query getPayloadTypesC2ProfilesQuery($payloadType: String!, $operation_id: Int!)
       description
       display_name
       format_string
+      group_name
       id
       name
       parameter_type
@@ -59,6 +60,7 @@ query getProfileInstanceQuery($name: String!, $operation_id: Int!, $c2_profile_i
       description
       display_name
       format_string
+      group_name
       id
       name
       parameter_type
@@ -86,6 +88,7 @@ query getDefaultC2ProfileParameters($c2profile_id: Int!) {
         description
         display_name
         format_string
+        group_name
         id
         name
         parameter_type

--- a/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
@@ -45,6 +45,7 @@ query getPayloadTypesC2ProfilesQuery($payloadType: String!, $operation_id: Int!)
       choices
       ui_position
       choices_display_names
+      form_schema
     }
     c2profileparametersinstances(where: {instance_name: {_is_null: false}, operation_id: {_eq: $operation_id}}, distinct_on: instance_name, order_by: {instance_name: asc}){
         instance_name
@@ -71,6 +72,7 @@ query getProfileInstanceQuery($name: String!, $operation_id: Int!, $c2_profile_i
       choices
       ui_position
       choices_display_names
+      form_schema
       c2profile {
           name
       }
@@ -100,6 +102,7 @@ query getDefaultC2ProfileParameters($c2profile_id: Int!) {
         choices
         ui_position
         choices_display_names
+        form_schema
       }
     }
   }

--- a/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
@@ -15,7 +15,6 @@ import {MythicAgentSVGIcon} from "../../MythicComponents/MythicAgentSVGIcon";
 import {CreatePayloadBuildParametersTable} from "./CreatePayloadBuildParametersTable";
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
-import { IconButton } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import {useMythicLazyQuery} from "../../utilities/useMythicLazyQuery";
 import {ConfigurationSummary} from "./Step1SelectOS";
@@ -621,9 +620,11 @@ const C2ProfileTabs = ({includedC2Profiles, onChange, os, onCloseTab, onChangeCr
                     <Tab key={c.name + index} label={
                         <div style={{display: "flex", alignItems: "center"}}>
                                 {c.name}
-                            <IconButton className="mythic-table-row-icon-action mythic-table-row-icon-action-hover-danger" size='small' onClick={(e) => onCloseTabLocal(e, index)} >
+                            <span role="button" aria-label="close tab"
+                                  onClick={(e) => onCloseTabLocal(e, index)}
+                                  style={{display: "inline-flex", alignItems: "center", cursor: "pointer", marginLeft: "4px"}}>
                                 <CloseIcon fontSize="small" />
-                            </IconButton>
+                            </span>
                         </div>
                     } {...a11yProps(index)} style={{flexShrink: 0}} />
                 ))}

--- a/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
@@ -44,6 +44,7 @@ query getPayloadTypesC2ProfilesQuery($payloadType: String!, $operation_id: Int!)
       verifier_regex
       choices
       ui_position
+      choices_display_names
     }
     c2profileparametersinstances(where: {instance_name: {_is_null: false}, operation_id: {_eq: $operation_id}}, distinct_on: instance_name, order_by: {instance_name: asc}){
         instance_name
@@ -69,6 +70,7 @@ query getProfileInstanceQuery($name: String!, $operation_id: Int!, $c2_profile_i
       verifier_regex
       choices
       ui_position
+      choices_display_names
       c2profile {
           name
       }
@@ -97,6 +99,7 @@ query getDefaultC2ProfileParameters($c2profile_id: Int!) {
         verifier_regex
         choices
         ui_position
+        choices_display_names
       }
     }
   }

--- a/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
+++ b/MythicReactUI/src/components/pages/CreatePayload/Step4C2Profiles.js
@@ -450,7 +450,11 @@ export function Step4C2Profiles(props){
                         </div>
                     </div>
                     <div className="mythic-create-builder-split" style={summaryCollapsed ? {gridTemplateColumns: "3rem minmax(0, 1fr)"} : undefined}>
-                        <section className="mythic-create-section mythic-create-section-scroll" style={summaryCollapsed ? {alignItems: "center", paddingLeft: "0.25rem", paddingRight: "0.25rem"} : undefined}>
+                        <section
+                            className="mythic-create-section mythic-create-section-scroll"
+                            style={summaryCollapsed ? {alignItems: "center", cursor: "pointer", paddingLeft: "0.25rem", paddingRight: "0.25rem"} : undefined}
+                            onClick={summaryCollapsed ? () => setSummaryCollapsed(false) : undefined}
+                        >
                             <div style={{display: "flex", alignItems: "center", justifyContent: summaryCollapsed ? "center" : "space-between", gap: "0.5rem"}}>
                                 {!summaryCollapsed && (
                                     <Typography component="div" className="mythic-create-section-title" style={{textAlign: "center", flexGrow: 1}}>
@@ -459,10 +463,26 @@ export function Step4C2Profiles(props){
                                 )}
                                 <IconButton size="small"
                                             aria-label={summaryCollapsed ? "Expand configuration summary" : "Collapse configuration summary"}
-                                            onClick={() => setSummaryCollapsed(prev => !prev)}>
+                                            title={summaryCollapsed ? "Expand" : "Collapse"}
+                                            onClick={(e) => { e.stopPropagation(); setSummaryCollapsed(prev => !prev); }}>
                                     {summaryCollapsed ? <ChevronRightIcon fontSize="small" /> : <ChevronLeftIcon fontSize="small" />}
                                 </IconButton>
                             </div>
+                            {summaryCollapsed && (
+                                <div style={{flexGrow: 1, display: "flex", alignItems: "center", justifyContent: "center", userSelect: "none"}}>
+                                    <Typography variant={"body2"} style={{
+                                        fontWeight: 600,
+                                        writingMode: "vertical-rl",
+                                        transform: "rotate(180deg)",
+                                        letterSpacing: 0,
+                                        textTransform: "uppercase",
+                                        fontSize: "0.75rem",
+                                        opacity: 0.75,
+                                    }}>
+                                        Configuration Summary
+                                    </Typography>
+                                </div>
+                            )}
                             {!summaryCollapsed && includedC2Profiles.map( (c, index) => (
                                 <ConfigurationSummary key={c.name + index} buildParameters={c.c2profileparameters}
                                                       os={props.buildOptions.os} c2_name={c.name} />

--- a/MythicReactUI/src/components/pages/Payloads/DetailedPayloadTable.js
+++ b/MythicReactUI/src/components/pages/Payloads/DetailedPayloadTable.js
@@ -315,6 +315,13 @@ export const ParseForDisplay = ({
 }) => {
     const [renderObj, setRenderObj] = React.useState('');
     const [fileMultipleValue, setFileMultipleValue] = React.useState([]);
+    const choiceLabel = (val) => {
+        const m = cmd?.choices_display_names;
+        if(m && typeof m === "object" && val in m && typeof m[val] === "string" && m[val].length > 0){
+            return m[val];
+        }
+        return val;
+    };
     React.useEffect( () => {
         if(cmd.parameter_type === "Dictionary") {
             try{
@@ -336,17 +343,15 @@ export const ParseForDisplay = ({
             }
         }else if(cmd.parameter_type === "Array" || cmd.parameter_type === "ChooseMultiple") {
             try {
-                if(typeof cmd.value === 'string'){
-                    let parsedValue = JSON.parse(cmd.value);
-                    setRenderObj(parsedValue.map(c => c + "\n"));
-                } else {
-                    setRenderObj(cmd.value.map(c => c + "\n"));
-                }
-
+                const raw = (typeof cmd.value === 'string') ? JSON.parse(cmd.value) : cmd.value;
+                const mapped = (cmd.parameter_type === "ChooseMultiple") ? raw.map(choiceLabel) : raw;
+                setRenderObj(mapped.map(c => c + "\n"));
             } catch (error) {
                 console.log("Failed to parse parameter value as array or choose multiple", cmd.value, error)
                 setRenderObj(cmd.value);
             }
+        } else if(cmd.parameter_type === "ChooseOne" || cmd.parameter_type === "ChooseOneCustom") {
+            setRenderObj(choiceLabel(cmd.value));
         } else if(cmd.parameter_type === "File") {
         } else if(cmd.parameter_type === "FileMultiple") {
             try {

--- a/form_schema_spec.md
+++ b/form_schema_spec.md
@@ -1,0 +1,439 @@
+# `form_schema` Specification
+
+`form_schema` is a declarative JSON document that describes a structured form. Mythic's
+Create-Payload UI renders it as the **Visual** editor for a C2 profile parameter, giving
+operators a guided form instead of hand-editing a raw JSON config blob.
+
+This document is the authoritative reference for the wire-format vocabulary. It is derived
+from the renderer that consumes it — `MythicReactUI/src/components/pages/CreatePayload/SchemaFormRenderer.js`
+— and the integration in `CreatePayloadParameter.js`. If you change the renderer, update
+this file in the same commit.
+
+---
+
+## 1. Where `form_schema` lives
+
+`form_schema` is a first-class field on a **C2 profile parameter**. It travels with the rest
+of the parameter metadata through the c2 sync pipeline; there is no separate RPC call to fetch
+it.
+
+| Layer | Location |
+|-------|----------|
+| Sync struct | `C2Parameter.FormSchema` — `map[string]interface{}` / JSON key `form_schema` (`mythic-docker/src/rabbitmq/recv_c2_sync.go`) |
+| DB struct | `C2profileparameters.FormSchema` — `MythicJSONText`, column `form_schema` (`mythic-docker/src/database/structs/C2profileparameters.go`) |
+| Schema | `form_schema jsonb NOT NULL DEFAULT '{}'` on `c2profileparameters` (migration `3.3.21`, version `3003021`) |
+| GraphQL | exposed as `form_schema` to all parameter-reading roles; fetched by `Step1SelectOS` and `Step4C2Profiles` |
+| UI consumer | `CreatePayloadParameter` → `SchemaFormRenderer` |
+
+A parameter ships a schema simply by populating this field during sync. No `form_fn=`
+convention, no per-modal lookup.
+
+---
+
+## 2. When the Visual editor appears
+
+The Visual editor is **not** shown for every parameter that has a `form_schema`. Two
+conditions must both hold:
+
+1. **The parameter opts into the config editor.** This applies only to a `String`
+   parameter whose `format_string` begins with `ui:config_editor` (see `getConfigEditorMode`
+   in `CreatePayloadParameter.js`). That gives the parameter the Upload / Edit / Source
+   experience inside a dialog.
+
+2. **The schema is valid** (`hasFormSchema`). The renderer treats `form_schema` as usable
+   only when it is:
+   - a non-`null` value,
+   - an `object` (not an array), and
+   - has a `type` that is a non-empty string.
+
+   ```js
+   const hasFormSchema = !!(form_schema
+       && typeof form_schema === "object"
+       && !Array.isArray(form_schema)
+       && typeof form_schema.type === "string"
+       && form_schema.type.length > 0);
+   ```
+
+When both hold, the config-editor dialog shows **Visual** and **Source** tabs. Otherwise only
+the raw Source editor is shown.
+
+> The `form_schema` column is `NOT NULL DEFAULT '{}'`, so a parameter that ships no schema
+> carries an empty object. `{}` has no `type`, so it fails the gate above and only the Source
+> editor is shown — exactly the intended "no schema" behavior.
+
+### The JSON round-trip
+
+The parameter's stored value is a **string** (the raw config). The Visual editor is a view
+over the JSON parse of that string:
+
+- **Entering Visual:** the current source is `JSON.parse`d into the value tree the form edits.
+  If the source is empty, the tree is seeded with `emptyValueForSchema(form_schema)`
+  (see §6). If the source is **not valid JSON**, the switch is blocked and an error is shown —
+  so a TOML config cannot use the Visual tab.
+- **Editing in Visual:** every change is serialized back with `JSON.stringify(value, null, 2)`
+  and written to the parameter value.
+
+**Consequence:** the top-level `form_schema` should describe a JSON document — in practice
+`{"type": "object", ...}` (an `array` or `string_map` root also works). It must round-trip
+cleanly through `JSON.parse` / `JSON.stringify`.
+
+---
+
+## 3. The schema descriptor
+
+Every node in a `form_schema` is a JSON object with a `type`. `type` is **required**; an
+unrecognized `type` renders a visible `Unknown schema type: <x>` notice rather than failing.
+
+Supported types:
+
+| `type` | Renders as | Value shape |
+|--------|------------|-------------|
+| `object` | a group of named sub-fields | JSON object keyed by each field's `name` |
+| `array` | a repeatable list with Add/Delete | JSON array |
+| `enum` | a dropdown (`Select`) | one chosen value |
+| `string` | single-line/multi-line text field | string |
+| `number` | numeric text field | number |
+| `boolean` | a toggle (`Switch`) | boolean |
+| `string_map` | an editable key/value table | JSON object (string→string) |
+
+### Fields common to all types
+
+| Key | Type | Applies to | Effect |
+|-----|------|-----------|--------|
+| `type` | string | all | **Required.** Selects the renderer. |
+| `label` | string | all | Human-readable heading/caption. See per-type notes for placement and the collapsible behavior it triggers. |
+| `description` | string | all | Secondary helper text shown under the control. |
+
+---
+
+## 4. Type reference
+
+### 4.1 `object`
+
+```json
+{
+  "type": "object",
+  "label": "HTTP Profile",
+  "description": "Top-level configuration",
+  "fields": [
+    { "name": "port", "type": "number", "label": "Port" },
+    { "name": "use_ssl", "type": "boolean", "label": "Use SSL" }
+  ]
+}
+```
+
+| Key | Type | Required | Notes |
+|-----|------|----------|-------|
+| `fields` | array of schemas | yes | Each entry is itself a full schema descriptor **plus** a `name`. |
+
+**`name` is mandatory on every entry in `fields`.** It is the JSON key the sub-value is stored
+under and the React key used for rendering. Two fields with the same `name` collide.
+
+Each field in `fields` may additionally carry `show_when` (§5.1) and `placeholder_when`
+(§5.2).
+
+**Layout / nesting behavior:**
+
+- The **top-level** object (depth 0) renders with no surrounding card; its `label` is a bold
+  heading. Content flows in the dialog's natural padding.
+- A **nested** object (inside another object or an array) renders with a soft left-border
+  accent and indentation.
+  - If the nested object has a `label`, it is wrapped in a **collapsible section** (expandable
+    header showing the label, plus the `description` underneath when expanded). Sections start
+    **expanded**; there is no schema key to start a section collapsed.
+  - If it has no `label`, it renders as a plain indented block.
+
+### 4.2 `array`
+
+```json
+{
+  "type": "array",
+  "label": "URIs",
+  "description": "Request paths the agent will use",
+  "items": { "type": "string" }
+}
+```
+
+| Key | Type | Required | Notes |
+|-----|------|----------|-------|
+| `items` | schema | yes | Schema for every element. Defaults to `{"type": "string"}` if omitted on the primitive path. |
+
+Behavior:
+
+- An **Add** button appends a new element seeded with `emptyValueForSchema(items)` (§6); each
+  row has a delete button.
+- When the array has a `label`, it is a collapsible section whose header shows a live count,
+  e.g. `URIs (3)`, plus the `description`.
+- **Array of objects** (`items.type === "object"`): each element is rendered in its own
+  outlined card containing the item's `fields`. `show_when` / `placeholder_when` on those
+  fields are evaluated **per element** against that element's own value.
+- **Array of primitives** (anything else): each element is rendered with the item control and
+  a delete button.
+
+> Note: the `items` schema's own `label` is **not** displayed (it is stripped for primitive
+> items and unused for object items). Put the human-readable name on the **array** node via
+> its `label`.
+
+### 4.3 `enum`
+
+```json
+{
+  "type": "enum",
+  "label": "Method",
+  "choices": ["GET", "POST"],
+  "choiceLabels": { "GET": "HTTP GET", "POST": "HTTP POST" }
+}
+```
+
+| Key | Type | Required | Notes |
+|-----|------|----------|-------|
+| `choices` | array | yes | The selectable values. Each is used as both the stored value and the option key, so use **unique primitives** (strings recommended). |
+| `choiceLabels` | object | no | Map of `value → display text`. A value with no entry shows its raw value. |
+
+> The display-label key here is **`choiceLabels`** (camelCase), distinct from the
+> `choices_display_names` field used by Mythic's native parameter types. Don't confuse them.
+
+Empty value defaults to the first choice (or `""` if `choices` is empty).
+
+### 4.4 `string`
+
+```json
+{ "type": "string", "label": "Host", "placeholder": "example.com" }
+```
+
+| Key | Type | Required | Notes |
+|-----|------|----------|-------|
+| `placeholder` | string | no | Hint text shown when empty. Can be made conditional via `placeholder_when` (§5.2). |
+
+Renders a full-width text field. Empty value default is `""`.
+
+### 4.5 `number`
+
+```json
+{ "type": "number", "label": "Interval" }
+```
+
+Renders a numeric text field. Input is coerced with `Number(...)`; empty value default is `0`.
+
+### 4.6 `boolean`
+
+```json
+{ "type": "boolean", "label": "Enabled" }
+```
+
+Renders a toggle switch. Value is coerced with `!!`; empty value default is `false`.
+
+### 4.7 `string_map`
+
+```json
+{
+  "type": "string_map",
+  "label": "Headers",
+  "keyLabel": "Header",
+  "valueLabel": "Contents"
+}
+```
+
+| Key | Type | Required | Default | Notes |
+|-----|------|----------|---------|-------|
+| `keyLabel` | string | no | `"Key"` | Column label for keys. |
+| `valueLabel` | string | no | `"Value"` | Column label for values. |
+
+Renders an editable table of string→string entries:
+
+- **Add entry** inserts a fresh key (`new_key`, then `new_key_1`, … to avoid collisions) with
+  an empty value.
+- A key is renamed **on blur**; values update live.
+- When it has a `label`, it is a collapsible section with a live entry count.
+
+Empty value default is `{}`.
+
+---
+
+## 5. Conditional rendering
+
+These modifiers live on a **field within an object's `fields[]`** (or within an
+array-of-object item's `fields[]`). They are evaluated against the **sibling** values in the
+same object/element.
+
+### 5.1 `show_when` — conditional visibility
+
+```json
+{
+  "name": "key_path",
+  "type": "string",
+  "label": "Key Path",
+  "show_when": { "field": "action", "in": ["xor", "aes"] }
+}
+```
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `field` | string | Name of a sibling field whose value is consulted. |
+| `in` | array | The field renders only when the sibling's current value is in this list. |
+
+The field is rendered **iff** `siblingValue ∈ in`. If `show_when` is absent or malformed
+(missing `field`, or `in` is not an array), the field is always shown.
+
+> **Hidden fields keep their value.** Hiding only suppresses rendering — the field's existing
+> value remains in the object and will be serialized. Design your consumer to tolerate
+> stale-but-hidden keys, or clear them server-side.
+
+### 5.2 `placeholder_when` — conditional placeholder
+
+```json
+{
+  "name": "operand",
+  "type": "string",
+  "label": "Operand",
+  "placeholder_when": {
+    "field": "action",
+    "map": { "xor": "32-byte key", "prepend": "text to prepend" }
+  }
+}
+```
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `field` | string | Name of a sibling field whose value is the lookup key. |
+| `map` | object | `siblingValue → placeholder string`. |
+
+Before rendering, the renderer looks up the sibling's current value in `map`. If it resolves
+to a non-empty string, that string becomes the field's `placeholder`. No match (or the feature
+absent) leaves any static `placeholder` untouched. Only meaningful on `string` fields, since
+`placeholder` is consumed there.
+
+---
+
+## 6. Empty / default values
+
+When a value is missing (a new object field, a freshly added array element, an empty config on
+first Visual entry), the renderer seeds it from the schema via `emptyValueForSchema`:
+
+| `type` | Seeded value |
+|--------|--------------|
+| `object` | `{}` with every field recursively seeded under its `name` |
+| `array` | `[]` |
+| `enum` | first `choices` entry, or `""` if none |
+| `string` | `""` |
+| `number` | `0` |
+| `boolean` | `false` |
+| `string_map` | `{}` |
+| anything else | `null` |
+
+---
+
+## 7. Authoring notes & constraints
+
+- **Root type.** Because the Visual editor is a view over `JSON.parse(value)`, the root
+  `form_schema` should describe a JSON document — normally `{"type": "object", ...}`.
+- **Round-trip cleanliness.** The value must survive `JSON.parse` → edit → `JSON.stringify`.
+  Don't rely on comments, key ordering, or non-JSON syntax; those live only in the Source tab
+  and are lost the moment a value is edited in Visual.
+- **Name everything in `fields`.** Every object field needs a unique `name`.
+- **Label the container, not the item.** For `array`, put the display name on the array node;
+  `items.label` is ignored.
+- **`type` is required everywhere.** A node without a recognized `type` renders an
+  `Unknown schema type` notice.
+- **Schema is data, not code.** It is stored as `jsonb` and shipped over the sync pipeline;
+  keep it a plain JSON value with no functions or runtime references.
+
+---
+
+## 8. Worked example
+
+A complete schema for an HTTP-style C2 config, exercising nesting, arrays of objects,
+conditional fields, conditional placeholders, and a string map:
+
+```json
+{
+  "type": "object",
+  "label": "HTTP C2 Configuration",
+  "fields": [
+    { "name": "callback_host", "type": "string", "label": "Callback Host", "placeholder": "https://example.com" },
+    { "name": "callback_port", "type": "number", "label": "Callback Port" },
+    { "name": "use_ssl", "type": "boolean", "label": "Use SSL" },
+    {
+      "name": "get",
+      "type": "object",
+      "label": "GET Transport",
+      "description": "Settings for GET-based polling",
+      "fields": [
+        { "name": "uris", "type": "array", "label": "URIs", "items": { "type": "string" } },
+        {
+          "name": "headers",
+          "type": "string_map",
+          "label": "Headers",
+          "keyLabel": "Header",
+          "valueLabel": "Value"
+        }
+      ]
+    },
+    {
+      "name": "transforms",
+      "type": "array",
+      "label": "Message Transforms",
+      "items": {
+        "type": "object",
+        "fields": [
+          {
+            "name": "action",
+            "type": "enum",
+            "label": "Action",
+            "choices": ["base64", "xor", "prepend"],
+            "choiceLabels": { "base64": "Base64", "xor": "XOR", "prepend": "Prepend" }
+          },
+          {
+            "name": "value",
+            "type": "string",
+            "label": "Value",
+            "show_when": { "field": "action", "in": ["xor", "prepend"] },
+            "placeholder_when": {
+              "field": "action",
+              "map": { "xor": "hex-encoded key", "prepend": "bytes to prepend" }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+This serializes to / parses from a JSON document like:
+
+```json
+{
+  "callback_host": "https://example.com",
+  "callback_port": 443,
+  "use_ssl": true,
+  "get": {
+    "uris": ["/index", "/data"],
+    "headers": { "User-Agent": "Mozilla/5.0" }
+  },
+  "transforms": [
+    { "action": "base64" },
+    { "action": "xor", "value": "deadbeef" }
+  ]
+}
+```
+
+---
+
+## 9. Quick reference
+
+```
+node            := { "type": <T>, "label"?, "description"?, ...type-specific }
+
+object          := { type:"object", fields: [ field, ... ] }
+field           := node + { name: <string>, show_when?, placeholder_when? }
+array           := { type:"array", items: node }
+enum            := { type:"enum", choices: [<v>,...], choiceLabels?: { <v>: <label> } }
+string          := { type:"string", placeholder? }
+number          := { type:"number" }
+boolean         := { type:"boolean" }
+string_map      := { type:"string_map", keyLabel?, valueLabel? }
+
+show_when       := { field: <siblingName>, in: [<v>, ...] }
+placeholder_when:= { field: <siblingName>, map: { <siblingValue>: <placeholder> } }
+```

--- a/form_schema_spec.md
+++ b/form_schema_spec.md
@@ -181,17 +181,18 @@ Behavior:
   "type": "enum",
   "label": "Method",
   "choices": ["GET", "POST"],
-  "choiceLabels": { "GET": "HTTP GET", "POST": "HTTP POST" }
+  "choices_display_names": { "GET": "HTTP GET", "POST": "HTTP POST" }
 }
 ```
 
 | Key | Type | Required | Notes |
 |-----|------|----------|-------|
 | `choices` | array | yes | The selectable values. Each is used as both the stored value and the option key, so use **unique primitives** (strings recommended). |
-| `choiceLabels` | object | no | Map of `value → display text`. A value with no entry shows its raw value. |
+| `choices_display_names` | object | no | Map of `value → display text`. A value with no entry shows its raw value. |
 
-> The display-label key here is **`choiceLabels`** (camelCase), distinct from the
-> `choices_display_names` field used by Mythic's native parameter types. Don't confuse them.
+> This is the same `choices_display_names` key Mythic uses for the display labels of its
+> native `ChooseOne` / `ChooseMultiple` parameters — same name, same meaning, so authors only
+> learn one convention.
 
 Empty value defaults to the first choice (or `""` if `choices` is empty).
 
@@ -229,15 +230,15 @@ Renders a toggle switch. Value is coerced with `!!`; empty value default is `fal
 {
   "type": "string_map",
   "label": "Headers",
-  "keyLabel": "Header",
-  "valueLabel": "Contents"
+  "key_label": "Header",
+  "value_label": "Contents"
 }
 ```
 
 | Key | Type | Required | Default | Notes |
 |-----|------|----------|---------|-------|
-| `keyLabel` | string | no | `"Key"` | Column label for keys. |
-| `valueLabel` | string | no | `"Value"` | Column label for values. |
+| `key_label` | string | no | `"Key"` | Column label for keys. |
+| `value_label` | string | no | `"Value"` | Column label for values. |
 
 Renders an editable table of string→string entries:
 
@@ -364,8 +365,8 @@ conditional fields, conditional placeholders, and a string map:
           "name": "headers",
           "type": "string_map",
           "label": "Headers",
-          "keyLabel": "Header",
-          "valueLabel": "Value"
+          "key_label": "Header",
+          "value_label": "Value"
         }
       ]
     },
@@ -381,7 +382,7 @@ conditional fields, conditional placeholders, and a string map:
             "type": "enum",
             "label": "Action",
             "choices": ["base64", "xor", "prepend"],
-            "choiceLabels": { "base64": "Base64", "xor": "XOR", "prepend": "Prepend" }
+            "choices_display_names": { "base64": "Base64", "xor": "XOR", "prepend": "Prepend" }
           },
           {
             "name": "value",
@@ -428,11 +429,11 @@ node            := { "type": <T>, "label"?, "description"?, ...type-specific }
 object          := { type:"object", fields: [ field, ... ] }
 field           := node + { name: <string>, show_when?, placeholder_when? }
 array           := { type:"array", items: node }
-enum            := { type:"enum", choices: [<v>,...], choiceLabels?: { <v>: <label> } }
+enum            := { type:"enum", choices: [<v>,...], choices_display_names?: { <v>: <label> } }
 string          := { type:"string", placeholder? }
 number          := { type:"number" }
 boolean         := { type:"boolean" }
-string_map      := { type:"string_map", keyLabel?, valueLabel? }
+string_map      := { type:"string_map", key_label?, value_label? }
 
 show_when       := { field: <siblingName>, in: [<v>, ...] }
 placeholder_when:= { field: <siblingName>, map: { <siblingValue>: <placeholder> } }

--- a/form_schema_spec.md
+++ b/form_schema_spec.md
@@ -322,9 +322,81 @@ first Visual entry), the renderer seeds it from the schema via `emptyValueForSch
 | `string_map` | `{}` |
 | anything else | `null` |
 
+> These are the **only** defaults `form_schema` provides — type-based zero values. There is no
+> per-node `default` key, and no per-node randomization. For author-supplied default *content*
+> and for randomized values, see §7.
+
 ---
 
-## 7. Authoring notes & constraints
+## 7. Defaults and randomization (parameter-level, not schema-level)
+
+`form_schema` describes **structure only**. The renderer reads no `default`, `randomize`, or
+`format_string` keys on any node — set them and they are silently ignored. Both "default data"
+and "random data" are governed one level up, by **peer fields on the C2 profile parameter**
+that carries the schema, not by the schema itself.
+
+### Where a form_schema field's initial content comes from
+
+When the operator opens the Visual editor, the form is populated in this order of precedence:
+
+1. **The parameter's current value / `default_value`** — a raw config **string**. The Visual tab
+   runs `JSON.parse` on it and edits the resulting tree (`parseSourceForVisual` in
+   `CreatePayloadParameter.js`). This is the real way to ship a non-trivial default: set the
+   parameter's `default_value` to a JSON string. (It must be JSON-parseable for Visual to seed
+   from it — see §2's round-trip rule.)
+2. **A preset** the operator picks from `presets_fn` — also a raw config string, parsed the same
+   way.
+3. **Type-based seeding** from §6 (`emptyValueForSchema`) when the source is empty — `""`, `0`,
+   `[]`, etc.
+
+So if you want the Visual form to open with meaningful values, put them in the parameter's
+`default_value` or ship presets; you cannot express them inside the schema.
+
+### Randomization is parameter-level — and mutually exclusive with the Visual editor
+
+A parameter gets a randomly-generated value via two peer fields:
+
+| Parameter field | Wire key | Effect |
+|-----------------|----------|--------|
+| `DefaultValue` | `default_value` | Static default value (any type matching the parameter type). |
+| `Randomize` | `randomize` | When `true`, generate the value from `FormatString` **as a regex**. |
+| `FormatString` | `format_string` | Dual-purpose: a randomize **regex**, *or* a `ui:config_editor:…` directive. Never both. |
+
+When `Randomize` is `true`, Mythic generates the value at build/instance time by feeding
+`FormatString` through its `reggen` regex generator (`mythic-docker/src/rabbitmq/utils.go:415`,
+`utils.Generate(formatString, 10)`), and `DefaultValue` is ignored.
+
+Because `FormatString` is dual-purpose, **a `form_schema`-backed field can never be randomized**:
+the Visual editor only exists for `ui:config_editor` String parameters, and `getConfigEditorMode`
+(`CreatePayloadParameter.js:67`) disables the config editor entirely whenever `randomize` is
+`true`. Put randomized values (keys, URIs, tokens) in their **own** parameters, separate from any
+config-editor/`form_schema` field.
+
+```go
+// A randomized value — its own parameter, NOT a form_schema field.
+{
+    Name:          "xor_key",
+    ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
+    Randomize:     true,
+    FormatString:  "[A-Fa-f0-9]{32}", // regex → fresh 16-byte hex key per build
+},
+// Default *content* for a form_schema-backed config field — set on the parameter as a
+// raw JSON string; the Visual tab parses it into the form when opened.
+{
+    Name:          "raw_c2_config",
+    ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
+    DefaultValue:  `{"get":{"uris":["/index"]}}`,
+    FormatString:  "ui:config_editor:json_toml:presets_fn=list_raw_c2_config_presets",
+},
+```
+
+> `reggen` caps **unbounded** quantifiers (`+`, `*`, `{n,}`) at 10 repetitions, so prefer an
+> explicit length (`{32}`) for keys. Anchors (`^`/`$`) aren't needed — it generates the whole
+> string from the pattern.
+
+---
+
+## 8. Authoring notes & constraints
 
 - **Root type.** Because the Visual editor is a view over `JSON.parse(value)`, the root
   `form_schema` should describe a JSON document — normally `{"type": "object", ...}`.
@@ -341,7 +413,7 @@ first Visual entry), the renderer seeds it from the schema via `emptyValueForSch
 
 ---
 
-## 8. Worked example
+## 9. Worked example
 
 A complete schema for an HTTP-style C2 config, exercising nesting, arrays of objects,
 conditional fields, conditional placeholders, and a string map:
@@ -421,7 +493,7 @@ This serializes to / parses from a JSON document like:
 
 ---
 
-## 9. Quick reference
+## 10. Quick reference
 
 ```
 node            := { "type": <T>, "label"?, "description"?, ...type-specific }

--- a/hasura-docker/metadata/actions.graphql
+++ b/hasura-docker/metadata/actions.graphql
@@ -278,6 +278,14 @@ type Mutation {
 }
 
 type Mutation {
+  c2CustomRPCFunction(
+    c2_profile: String!
+    function_name: String!
+    arguments: jsonb
+  ): c2CustomRPCFunctionOutput
+}
+
+type Mutation {
   dynamicQueryFunction(
     command: String!
     parameter_name: String!
@@ -1313,6 +1321,12 @@ type updatePayloadOutput {
 type eventingTriggerManualBulkOutput {
   status: String!
   error: String
+}
+
+type c2CustomRPCFunctionOutput {
+  status: String!
+  error: String
+  result: jsonb
 }
 
 type dynamicQueryBuildParameterOutput {

--- a/hasura-docker/metadata/actions.yaml
+++ b/hasura-docker/metadata/actions.yaml
@@ -398,6 +398,17 @@ actions:
       - role: operation_admin
       - role: mythic_admin
       - role: developer
+  - name: c2CustomRPCFunction
+    definition:
+      kind: synchronous
+      handler: '{{MYTHIC_ACTIONS_URL_BASE}}/c2_custom_rpc_function_webhook'
+      forward_client_headers: true
+    permissions:
+      - role: operator
+      - role: operation_admin
+      - role: mythic_admin
+      - role: developer
+    comment: Invoke a registered CustomRPCFunctions entry on a C2 profile, returning its result blob.
   - name: dynamicQueryFunction
     definition:
       kind: synchronous
@@ -1038,4 +1049,5 @@ custom_types:
     - name: eventingTriggerManualBulkOutput
     - name: dynamicQueryBuildParameterOutput
     - name: custombrowserExportFunctionOutput
+    - name: c2CustomRPCFunctionOutput
   scalars: []

--- a/hasura-docker/metadata/databases/default/tables/public_c2profileparameters.yaml
+++ b/hasura-docker/metadata/databases/default/tables/public_c2profileparameters.yaml
@@ -14,6 +14,25 @@ array_relationships:
           name: c2profileparametersinstance
           schema: public
 select_permissions:
+  - role: developer
+    permission:
+      columns:
+        - crypto_type
+        - deleted
+        - randomize
+        - required
+        - c2_profile_id
+        - id
+        - ui_position
+        - choices
+        - default_value
+        - description
+        - display_name
+        - format_string
+        - name
+        - parameter_type
+        - verifier_regex
+      filter: {}
   - role: mythic_admin
     permission:
       columns:
@@ -27,6 +46,7 @@ select_permissions:
         - choices
         - default_value
         - description
+        - display_name
         - format_string
         - name
         - parameter_type
@@ -45,6 +65,7 @@ select_permissions:
         - choices
         - default_value
         - description
+        - display_name
         - format_string
         - name
         - parameter_type
@@ -63,6 +84,7 @@ select_permissions:
         - choices
         - default_value
         - description
+        - display_name
         - format_string
         - name
         - parameter_type
@@ -81,6 +103,7 @@ select_permissions:
         - choices
         - default_value
         - description
+        - display_name
         - format_string
         - name
         - parameter_type

--- a/hasura-docker/metadata/databases/default/tables/public_c2profileparameters.yaml
+++ b/hasura-docker/metadata/databases/default/tables/public_c2profileparameters.yaml
@@ -27,7 +27,9 @@ select_permissions:
         - choices
         - default_value
         - description
+        - display_name
         - format_string
+        - group_name
         - name
         - parameter_type
         - verifier_regex
@@ -45,7 +47,9 @@ select_permissions:
         - choices
         - default_value
         - description
+        - display_name
         - format_string
+        - group_name
         - name
         - parameter_type
         - verifier_regex
@@ -63,7 +67,9 @@ select_permissions:
         - choices
         - default_value
         - description
+        - display_name
         - format_string
+        - group_name
         - name
         - parameter_type
         - verifier_regex
@@ -81,7 +87,9 @@ select_permissions:
         - choices
         - default_value
         - description
+        - display_name
         - format_string
+        - group_name
         - name
         - parameter_type
         - verifier_regex
@@ -99,7 +107,9 @@ select_permissions:
         - choices
         - default_value
         - description
+        - display_name
         - format_string
+        - group_name
         - name
         - parameter_type
         - verifier_regex

--- a/hasura-docker/metadata/databases/default/tables/public_c2profileparameters.yaml
+++ b/hasura-docker/metadata/databases/default/tables/public_c2profileparameters.yaml
@@ -25,6 +25,7 @@ select_permissions:
         - id
         - ui_position
         - choices
+        - choices_display_names
         - default_value
         - description
         - display_name
@@ -45,6 +46,7 @@ select_permissions:
         - id
         - ui_position
         - choices
+        - choices_display_names
         - default_value
         - description
         - display_name
@@ -65,6 +67,7 @@ select_permissions:
         - id
         - ui_position
         - choices
+        - choices_display_names
         - default_value
         - description
         - display_name
@@ -85,6 +88,7 @@ select_permissions:
         - id
         - ui_position
         - choices
+        - choices_display_names
         - default_value
         - description
         - display_name
@@ -105,6 +109,7 @@ select_permissions:
         - id
         - ui_position
         - choices
+        - choices_display_names
         - default_value
         - description
         - display_name

--- a/hasura-docker/metadata/databases/default/tables/public_c2profileparameters.yaml
+++ b/hasura-docker/metadata/databases/default/tables/public_c2profileparameters.yaml
@@ -27,7 +27,6 @@ select_permissions:
         - choices
         - default_value
         - description
-        - display_name
         - format_string
         - name
         - parameter_type
@@ -46,7 +45,6 @@ select_permissions:
         - choices
         - default_value
         - description
-        - display_name
         - format_string
         - name
         - parameter_type
@@ -65,7 +63,6 @@ select_permissions:
         - choices
         - default_value
         - description
-        - display_name
         - format_string
         - name
         - parameter_type
@@ -84,7 +81,6 @@ select_permissions:
         - choices
         - default_value
         - description
-        - display_name
         - format_string
         - name
         - parameter_type
@@ -103,7 +99,6 @@ select_permissions:
         - choices
         - default_value
         - description
-        - display_name
         - format_string
         - name
         - parameter_type

--- a/hasura-docker/metadata/databases/default/tables/public_c2profileparameters.yaml
+++ b/hasura-docker/metadata/databases/default/tables/public_c2profileparameters.yaml
@@ -29,6 +29,7 @@ select_permissions:
         - default_value
         - description
         - display_name
+        - form_schema
         - format_string
         - group_name
         - name
@@ -50,6 +51,7 @@ select_permissions:
         - default_value
         - description
         - display_name
+        - form_schema
         - format_string
         - group_name
         - name
@@ -71,6 +73,7 @@ select_permissions:
         - default_value
         - description
         - display_name
+        - form_schema
         - format_string
         - group_name
         - name
@@ -92,6 +95,7 @@ select_permissions:
         - default_value
         - description
         - display_name
+        - form_schema
         - format_string
         - group_name
         - name
@@ -113,6 +117,7 @@ select_permissions:
         - default_value
         - description
         - display_name
+        - form_schema
         - format_string
         - group_name
         - name

--- a/mythic-docker/src/database/initialize.go
+++ b/mythic-docker/src/database/initialize.go
@@ -15,7 +15,7 @@ import (
 )
 
 var DB *sqlx.DB
-var currentMigrationVersion int64 = 3003020
+var currentMigrationVersion int64 = 3003021
 
 // initial structs made with './tables-to-go -u mythic_user -p [password here] -h [ip here] -v -d mythic_db -of output -pn database_structs'
 // package pulled from https://github.com/fraenky8/tables-to-go

--- a/mythic-docker/src/database/migrations/003003018_3.3.18.sql
+++ b/mythic-docker/src/database/migrations/003003018_3.3.18.sql
@@ -2,8 +2,7 @@
 -- SQL in section 'Up' is executed when this migration is applied
 
 alter table "public"."filemeta" add column IF NOT EXISTS "received_chunk_ids" jsonb not null default jsonb_build_object();
+alter table "public"."c2profileparameters" add column IF NOT EXISTS "display_name" text not null default ''::text;
 
 -- +migrate Down
 -- SQL in section 'Down' is executed when this migration is rolled back
-
-

--- a/mythic-docker/src/database/migrations/003003019_3.3.19.sql
+++ b/mythic-docker/src/database/migrations/003003019_3.3.19.sql
@@ -3,6 +3,7 @@
 
 alter table "public"."apitokens" add column IF NOT EXISTS "scopes" text[] not null default '{}'::text[];
 drop table IF EXISTS "public"."browserscriptoperation";
+alter table "public"."c2profileparameters" add column IF NOT EXISTS "group_name" text not null default ''::text;
 
 -- +migrate Down
 -- SQL in section 'Down' is executed when this migration is rolled back

--- a/mythic-docker/src/database/migrations/003003020_3.3.20.sql
+++ b/mythic-docker/src/database/migrations/003003020_3.3.20.sql
@@ -162,6 +162,8 @@ end;
 $$;
 -- +migrate StatementEnd
 
+alter table "public"."c2profileparameters" add column IF NOT EXISTS "choices_display_names" jsonb not null default '{}'::jsonb;
+
 -- +migrate Down
 -- SQL in section 'Down' is executed when this migration is rolled back
 

--- a/mythic-docker/src/database/migrations/003003021_3.3.21.sql
+++ b/mythic-docker/src/database/migrations/003003021_3.3.21.sql
@@ -1,0 +1,6 @@
+-- +migrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+alter table "public"."c2profileparameters" add column IF NOT EXISTS "form_schema" jsonb not null default '{}'::jsonb;
+
+-- +migrate Down
+-- SQL in section 'Down' is executed when this migration is rolled back

--- a/mythic-docker/src/database/schema.go
+++ b/mythic-docker/src/database/schema.go
@@ -1002,6 +1002,8 @@ CREATE TABLE public.c2profileparameters (
     c2_profile_id integer NOT NULL,
     description text NOT NULL,
     name text NOT NULL,
+    display_name text DEFAULT ''::text NOT NULL,
+    group_name text DEFAULT ''::text NOT NULL,
     default_value text DEFAULT ''::text NOT NULL,
     randomize boolean DEFAULT false NOT NULL,
     format_string text DEFAULT ''::text NOT NULL,

--- a/mythic-docker/src/database/schema.go
+++ b/mythic-docker/src/database/schema.go
@@ -1012,7 +1012,8 @@ CREATE TABLE public.c2profileparameters (
     verifier_regex text DEFAULT ''::text NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     crypto_type boolean DEFAULT false NOT NULL,
-    choices jsonb DEFAULT jsonb_build_array() NOT NULL
+    choices jsonb DEFAULT jsonb_build_array() NOT NULL,
+    choices_display_names jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 

--- a/mythic-docker/src/database/schema.go
+++ b/mythic-docker/src/database/schema.go
@@ -1013,7 +1013,8 @@ CREATE TABLE public.c2profileparameters (
     deleted boolean DEFAULT false NOT NULL,
     crypto_type boolean DEFAULT false NOT NULL,
     choices jsonb DEFAULT jsonb_build_array() NOT NULL,
-    choices_display_names jsonb DEFAULT '{}'::jsonb NOT NULL
+    choices_display_names jsonb DEFAULT '{}'::jsonb NOT NULL,
+    form_schema jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 

--- a/mythic-docker/src/database/structs/C2profileparameters.go
+++ b/mythic-docker/src/database/structs/C2profileparameters.go
@@ -6,6 +6,7 @@ type C2profileparameters struct {
 	Description   string          `db:"description"`
 	Name          string          `db:"name"`
 	DisplayName   string          `db:"display_name"`
+	GroupName     string          `db:"group_name"`
 	DefaultValue  string          `db:"default_value"`
 	Randomize     bool            `db:"randomize"`
 	FormatString  string          `db:"format_string"`

--- a/mythic-docker/src/database/structs/C2profileparameters.go
+++ b/mythic-docker/src/database/structs/C2profileparameters.go
@@ -5,6 +5,7 @@ type C2profileparameters struct {
 	C2ProfileID   int             `db:"c2_profile_id"`
 	Description   string          `db:"description"`
 	Name          string          `db:"name"`
+	DisplayName   string          `db:"display_name"`
 	DefaultValue  string          `db:"default_value"`
 	Randomize     bool            `db:"randomize"`
 	FormatString  string          `db:"format_string"`

--- a/mythic-docker/src/database/structs/C2profileparameters.go
+++ b/mythic-docker/src/database/structs/C2profileparameters.go
@@ -17,5 +17,6 @@ type C2profileparameters struct {
 	IsCryptoType  bool            `db:"crypto_type"`
 	Choices              MythicJSONArray `db:"choices"`
 	ChoicesDisplayNames  MythicJSONText  `db:"choices_display_names"`
+	FormSchema           MythicJSONText  `db:"form_schema"`
 	UiPosition           int             `db:"ui_position"`
 }

--- a/mythic-docker/src/database/structs/C2profileparameters.go
+++ b/mythic-docker/src/database/structs/C2profileparameters.go
@@ -15,6 +15,7 @@ type C2profileparameters struct {
 	VerifierRegex string          `db:"verifier_regex"`
 	Deleted       bool            `db:"deleted"`
 	IsCryptoType  bool            `db:"crypto_type"`
-	Choices       MythicJSONArray `db:"choices"`
-	UiPosition    int             `db:"ui_position"`
+	Choices              MythicJSONArray `db:"choices"`
+	ChoicesDisplayNames  MythicJSONText  `db:"choices_display_names"`
+	UiPosition           int             `db:"ui_position"`
 }

--- a/mythic-docker/src/rabbitmq/constants.go
+++ b/mythic-docker/src/rabbitmq/constants.go
@@ -150,6 +150,8 @@ const (
 	//
 	C2_RPC_HOST_FILE = "c2_rpc_host_file"
 	//
+	MYTHIC_RPC_OTHER_SERVICES_RPC = "mythic_rpc_other_service_rpc"
+	//
 	CONTAINER_RPC_GET_FILE = "container_rpc_get_file"
 	//
 	CONTAINER_RPC_REMOVE_FILE = "container_rpc_remove_file"

--- a/mythic-docker/src/rabbitmq/recv_c2_sync.go
+++ b/mythic-docker/src/rabbitmq/recv_c2_sync.go
@@ -68,10 +68,11 @@ type C2Parameter struct {
 	Required          bool                  `json:"required"`
 	VerifierRegex     string                `json:"verifier_regex"`
 	IsCryptoType      bool                  `json:"crypto_type"`
-	Choices             []string              `json:"choices"`
-	ChoicesDisplayNames map[string]string     `json:"choices_display_names"`
-	DictionaryChoices   []ParameterDictionary `json:"dictionary_choices"`
-	UIPosition          int                   `json:"ui_position"`
+	Choices             []string               `json:"choices"`
+	ChoicesDisplayNames map[string]string      `json:"choices_display_names"`
+	DictionaryChoices   []ParameterDictionary  `json:"dictionary_choices"`
+	UIPosition          int                    `json:"ui_position"`
+	FormSchema          map[string]interface{} `json:"form_schema"`
 }
 
 type ParameterDictionary struct {
@@ -299,9 +300,17 @@ func updateC2Parameters(in C2SyncMessage, c2Profile databaseStructs.C2profile) e
 						} else {
 							databaseParameter.ChoicesDisplayNames = databaseStructs.MythicJSONText(cdnBytes)
 						}
+						if newParameter.FormSchema == nil {
+							databaseParameter.FormSchema = databaseStructs.MythicJSONText("{}")
+						} else if fsBytes, err := json.Marshal(newParameter.FormSchema); err != nil {
+							logging.LogError(err, "Failed to marshal FormSchema", "name", newParameter.Name)
+							databaseParameter.FormSchema = databaseStructs.MythicJSONText("{}")
+						} else {
+							databaseParameter.FormSchema = databaseStructs.MythicJSONText(fsBytes)
+						}
 						if _, err = database.DB.NamedExec(`UPDATE c2profileparameters SET
 							description=:description, display_name=:display_name, group_name=:group_name, default_value=:default_value, randomize=:randomize, format_string=:format_string,
-							parameter_type=:parameter_type, required=:required, choices=:choices, choices_display_names=:choices_display_names,
+							parameter_type=:parameter_type, required=:required, choices=:choices, choices_display_names=:choices_display_names, form_schema=:form_schema,
 							verifier_regex=:verifier_regex, deleted=:deleted,
 							crypto_type=:crypto_type, ui_position=:ui_position
 							WHERE id=:id`, databaseParameter,
@@ -363,11 +372,19 @@ func updateC2Parameters(in C2SyncMessage, c2Profile databaseStructs.C2profile) e
 			} else {
 				databaseParameter.ChoicesDisplayNames = databaseStructs.MythicJSONText(cdnBytes)
 			}
+			if newParameter.FormSchema == nil {
+				databaseParameter.FormSchema = databaseStructs.MythicJSONText("{}")
+			} else if fsBytes, err := json.Marshal(newParameter.FormSchema); err != nil {
+				logging.LogError(err, "Failed to marshal FormSchema", "name", newParameter.Name)
+				databaseParameter.FormSchema = databaseStructs.MythicJSONText("{}")
+			} else {
+				databaseParameter.FormSchema = databaseStructs.MythicJSONText(fsBytes)
+			}
 			if statement, err := database.DB.PrepareNamed(`INSERT INTO c2profileparameters
 				("name",display_name,group_name,description,default_value,randomize,format_string,verifier_regex,deleted,
-				 crypto_type,required,parameter_type,c2_profile_id,choices,choices_display_names, ui_position)
+				 crypto_type,required,parameter_type,c2_profile_id,choices,choices_display_names,form_schema, ui_position)
 				VALUES (:name, :display_name, :group_name, :description, :default_value, :randomize, :format_string, :verifier_regex, :deleted,
-				:crypto_type, :required, :parameter_type, :c2_profile_id, :choices, :choices_display_names, :ui_position)
+				:crypto_type, :required, :parameter_type, :c2_profile_id, :choices, :choices_display_names, :form_schema, :ui_position)
 				RETURNING id`,
 			); err != nil {
 				logging.LogError(err, "Failed to create new c2 profile parameters statement when importing c2 profile")

--- a/mythic-docker/src/rabbitmq/recv_c2_sync.go
+++ b/mythic-docker/src/rabbitmq/recv_c2_sync.go
@@ -68,9 +68,10 @@ type C2Parameter struct {
 	Required          bool                  `json:"required"`
 	VerifierRegex     string                `json:"verifier_regex"`
 	IsCryptoType      bool                  `json:"crypto_type"`
-	Choices           []string              `json:"choices"`
-	DictionaryChoices []ParameterDictionary `json:"dictionary_choices"`
-	UIPosition        int                   `json:"ui_position"`
+	Choices             []string              `json:"choices"`
+	ChoicesDisplayNames map[string]string     `json:"choices_display_names"`
+	DictionaryChoices   []ParameterDictionary `json:"dictionary_choices"`
+	UIPosition          int                   `json:"ui_position"`
 }
 
 type ParameterDictionary struct {
@@ -290,9 +291,17 @@ func updateC2Parameters(in C2SyncMessage, c2Profile databaseStructs.C2profile) e
 						} else {
 							databaseParameter.Choices = choices
 						}
+						if newParameter.ChoicesDisplayNames == nil {
+							databaseParameter.ChoicesDisplayNames = databaseStructs.MythicJSONText("{}")
+						} else if cdnBytes, err := json.Marshal(newParameter.ChoicesDisplayNames); err != nil {
+							logging.LogError(err, "Failed to marshal ChoicesDisplayNames", "name", newParameter.Name)
+							databaseParameter.ChoicesDisplayNames = databaseStructs.MythicJSONText("{}")
+						} else {
+							databaseParameter.ChoicesDisplayNames = databaseStructs.MythicJSONText(cdnBytes)
+						}
 						if _, err = database.DB.NamedExec(`UPDATE c2profileparameters SET
 							description=:description, display_name=:display_name, group_name=:group_name, default_value=:default_value, randomize=:randomize, format_string=:format_string,
-							parameter_type=:parameter_type, required=:required, choices=:choices,
+							parameter_type=:parameter_type, required=:required, choices=:choices, choices_display_names=:choices_display_names,
 							verifier_regex=:verifier_regex, deleted=:deleted,
 							crypto_type=:crypto_type, ui_position=:ui_position
 							WHERE id=:id`, databaseParameter,
@@ -346,11 +355,19 @@ func updateC2Parameters(in C2SyncMessage, c2Profile databaseStructs.C2profile) e
 			} else {
 				databaseParameter.Choices = choices
 			}
+			if newParameter.ChoicesDisplayNames == nil {
+				databaseParameter.ChoicesDisplayNames = databaseStructs.MythicJSONText("{}")
+			} else if cdnBytes, err := json.Marshal(newParameter.ChoicesDisplayNames); err != nil {
+				logging.LogError(err, "Failed to marshal ChoicesDisplayNames", "name", newParameter.Name)
+				databaseParameter.ChoicesDisplayNames = databaseStructs.MythicJSONText("{}")
+			} else {
+				databaseParameter.ChoicesDisplayNames = databaseStructs.MythicJSONText(cdnBytes)
+			}
 			if statement, err := database.DB.PrepareNamed(`INSERT INTO c2profileparameters
 				("name",display_name,group_name,description,default_value,randomize,format_string,verifier_regex,deleted,
-				 crypto_type,required,parameter_type,c2_profile_id,choices, ui_position)
+				 crypto_type,required,parameter_type,c2_profile_id,choices,choices_display_names, ui_position)
 				VALUES (:name, :display_name, :group_name, :description, :default_value, :randomize, :format_string, :verifier_regex, :deleted,
-				:crypto_type, :required, :parameter_type, :c2_profile_id, :choices, :ui_position)
+				:crypto_type, :required, :parameter_type, :c2_profile_id, :choices, :choices_display_names, :ui_position)
 				RETURNING id`,
 			); err != nil {
 				logging.LogError(err, "Failed to create new c2 profile parameters statement when importing c2 profile")

--- a/mythic-docker/src/rabbitmq/recv_c2_sync.go
+++ b/mythic-docker/src/rabbitmq/recv_c2_sync.go
@@ -60,6 +60,7 @@ type C2Parameter struct {
 	Description       string                `json:"description"`
 	Name              string                `json:"name"`
 	DisplayName       string                `json:"display_name"`
+	GroupName         string                `json:"group_name"`
 	DefaultValue      interface{}           `json:"default_value"`
 	Randomize         bool                  `json:"randomize"`
 	FormatString      string                `json:"format_string"`
@@ -269,6 +270,7 @@ func updateC2Parameters(in C2SyncMessage, c2Profile databaseStructs.C2profile) e
 						// update it
 						databaseParameter.Description = newParameter.Description
 						databaseParameter.DisplayName = newParameter.DisplayName
+						databaseParameter.GroupName = newParameter.GroupName
 						databaseParameter.Randomize = newParameter.Randomize
 						databaseParameter.FormatString = newParameter.FormatString
 						databaseParameter.ParameterType = newParameter.ParameterType
@@ -289,7 +291,7 @@ func updateC2Parameters(in C2SyncMessage, c2Profile databaseStructs.C2profile) e
 							databaseParameter.Choices = choices
 						}
 						if _, err = database.DB.NamedExec(`UPDATE c2profileparameters SET
-							description=:description, display_name=:display_name, default_value=:default_value, randomize=:randomize, format_string=:format_string,
+							description=:description, display_name=:display_name, group_name=:group_name, default_value=:default_value, randomize=:randomize, format_string=:format_string,
 							parameter_type=:parameter_type, required=:required, choices=:choices,
 							verifier_regex=:verifier_regex, deleted=:deleted,
 							crypto_type=:crypto_type, ui_position=:ui_position
@@ -321,6 +323,7 @@ func updateC2Parameters(in C2SyncMessage, c2Profile databaseStructs.C2profile) e
 			databaseParameter = databaseStructs.C2profileparameters{
 				Name:          newParameter.Name,
 				DisplayName:   newParameter.DisplayName,
+				GroupName:     newParameter.GroupName,
 				Description:   newParameter.Description,
 				Randomize:     newParameter.Randomize,
 				FormatString:  newParameter.FormatString,
@@ -344,9 +347,9 @@ func updateC2Parameters(in C2SyncMessage, c2Profile databaseStructs.C2profile) e
 				databaseParameter.Choices = choices
 			}
 			if statement, err := database.DB.PrepareNamed(`INSERT INTO c2profileparameters
-				("name",display_name,description,default_value,randomize,format_string,verifier_regex,deleted,
+				("name",display_name,group_name,description,default_value,randomize,format_string,verifier_regex,deleted,
 				 crypto_type,required,parameter_type,c2_profile_id,choices, ui_position)
-				VALUES (:name, :display_name, :description, :default_value, :randomize, :format_string, :verifier_regex, :deleted,
+				VALUES (:name, :display_name, :group_name, :description, :default_value, :randomize, :format_string, :verifier_regex, :deleted,
 				:crypto_type, :required, :parameter_type, :c2_profile_id, :choices, :ui_position)
 				RETURNING id`,
 			); err != nil {

--- a/mythic-docker/src/rabbitmq/recv_c2_sync.go
+++ b/mythic-docker/src/rabbitmq/recv_c2_sync.go
@@ -59,6 +59,7 @@ const (
 type C2Parameter struct {
 	Description       string                `json:"description"`
 	Name              string                `json:"name"`
+	DisplayName       string                `json:"display_name"`
 	DefaultValue      interface{}           `json:"default_value"`
 	Randomize         bool                  `json:"randomize"`
 	FormatString      string                `json:"format_string"`
@@ -267,6 +268,7 @@ func updateC2Parameters(in C2SyncMessage, c2Profile databaseStructs.C2profile) e
 						found = true
 						// update it
 						databaseParameter.Description = newParameter.Description
+						databaseParameter.DisplayName = newParameter.DisplayName
 						databaseParameter.Randomize = newParameter.Randomize
 						databaseParameter.FormatString = newParameter.FormatString
 						databaseParameter.ParameterType = newParameter.ParameterType
@@ -286,11 +288,11 @@ func updateC2Parameters(in C2SyncMessage, c2Profile databaseStructs.C2profile) e
 						} else {
 							databaseParameter.Choices = choices
 						}
-						if _, err = database.DB.NamedExec(`UPDATE c2profileparameters SET 
-							description=:description, default_value=:default_value, randomize=:randomize, format_string=:format_string,
+						if _, err = database.DB.NamedExec(`UPDATE c2profileparameters SET
+							description=:description, display_name=:display_name, default_value=:default_value, randomize=:randomize, format_string=:format_string,
 							parameter_type=:parameter_type, required=:required, choices=:choices,
-							verifier_regex=:verifier_regex, deleted=:deleted, 
-							crypto_type=:crypto_type, ui_position=:ui_position 
+							verifier_regex=:verifier_regex, deleted=:deleted,
+							crypto_type=:crypto_type, ui_position=:ui_position
 							WHERE id=:id`, databaseParameter,
 						); err != nil {
 							logging.LogError(err, "Failed to update c2 parameter in database", "c2_parameter", databaseParameter)
@@ -318,6 +320,7 @@ func updateC2Parameters(in C2SyncMessage, c2Profile databaseStructs.C2profile) e
 			// we have a new parameter group / command parameter to add in
 			databaseParameter = databaseStructs.C2profileparameters{
 				Name:          newParameter.Name,
+				DisplayName:   newParameter.DisplayName,
 				Description:   newParameter.Description,
 				Randomize:     newParameter.Randomize,
 				FormatString:  newParameter.FormatString,
@@ -340,11 +343,11 @@ func updateC2Parameters(in C2SyncMessage, c2Profile databaseStructs.C2profile) e
 			} else {
 				databaseParameter.Choices = choices
 			}
-			if statement, err := database.DB.PrepareNamed(`INSERT INTO c2profileparameters 
-				("name",description,default_value,randomize,format_string,verifier_regex,deleted,
-				 crypto_type,required,parameter_type,c2_profile_id,choices, ui_position) 
-				VALUES (:name, :description, :default_value, :randomize, :format_string, :verifier_regex, :deleted,
-				:crypto_type, :required, :parameter_type, :c2_profile_id, :choices, :ui_position) 
+			if statement, err := database.DB.PrepareNamed(`INSERT INTO c2profileparameters
+				("name",display_name,description,default_value,randomize,format_string,verifier_regex,deleted,
+				 crypto_type,required,parameter_type,c2_profile_id,choices, ui_position)
+				VALUES (:name, :display_name, :description, :default_value, :randomize, :format_string, :verifier_regex, :deleted,
+				:crypto_type, :required, :parameter_type, :c2_profile_id, :choices, :ui_position)
 				RETURNING id`,
 			); err != nil {
 				logging.LogError(err, "Failed to create new c2 profile parameters statement when importing c2 profile")

--- a/mythic-docker/src/rabbitmq/send_c2_rpc_other_service_rpc.go
+++ b/mythic-docker/src/rabbitmq/send_c2_rpc_other_service_rpc.go
@@ -1,0 +1,42 @@
+package rabbitmq
+
+import (
+	"encoding/json"
+
+	"github.com/its-a-feature/Mythic/logging"
+)
+
+type C2OtherServiceRPCMessage struct {
+	ServiceName                 string                 `json:"service_name"`
+	ServiceRPCFunction          string                 `json:"service_function"`
+	ServiceRPCFunctionArguments map[string]interface{} `json:"service_arguments"`
+}
+
+type C2OtherServiceRPCMessageResponse struct {
+	Success               bool                   `json:"success"`
+	Error                 string                 `json:"error"`
+	Result                map[string]interface{} `json:"result"`
+	RestartInternalServer bool                   `json:"restart_internal_server"`
+}
+
+func (r *rabbitMQConnection) SendC2RPCOtherService(msg C2OtherServiceRPCMessage) (*C2OtherServiceRPCMessageResponse, error) {
+	response := C2OtherServiceRPCMessageResponse{}
+	exclusiveQueue := true
+	if configBytes, err := json.Marshal(msg); err != nil {
+		logging.LogError(err, "Failed to marshal C2OtherServiceRPCMessage", "msg", msg)
+		return nil, err
+	} else if responseBytes, err := r.SendRPCMessage(
+		MYTHIC_EXCHANGE,
+		GetC2RPCOtherServiceRoutingKey(msg.ServiceName),
+		configBytes,
+		exclusiveQueue,
+	); err != nil {
+		logging.LogError(err, "Failed to send C2 other service RPC message")
+		return nil, err
+	} else if err := json.Unmarshal(responseBytes, &response); err != nil {
+		logging.LogError(err, "Failed to parse C2 other service RPC response")
+		return nil, err
+	} else {
+		return &response, nil
+	}
+}

--- a/mythic-docker/src/rabbitmq/utils_rabbitmq_routing.go
+++ b/mythic-docker/src/rabbitmq/utils_rabbitmq_routing.go
@@ -94,6 +94,9 @@ func GetC2RPCGetServerDebugOutputRoutingKey(container string) string {
 func GetC2RPCHostFileRoutingKey(container string) string {
 	return fmt.Sprintf("%s_%s", container, C2_RPC_HOST_FILE)
 }
+func GetC2RPCOtherServiceRoutingKey(container string) string {
+	return fmt.Sprintf("%s_%s", container, MYTHIC_RPC_OTHER_SERVICES_RPC)
+}
 func GetC2RPCGetFileRoutingKey(container string) string {
 	return fmt.Sprintf("%s_%s", container, CONTAINER_RPC_GET_FILE)
 }

--- a/mythic-docker/src/webserver/controllers/c2profile_custom_rpc_function_webhook.go
+++ b/mythic-docker/src/webserver/controllers/c2profile_custom_rpc_function_webhook.go
@@ -1,0 +1,67 @@
+package webcontroller
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/its-a-feature/Mythic/logging"
+	"github.com/its-a-feature/Mythic/rabbitmq"
+)
+
+type C2CustomRPCFunctionInput struct {
+	Input C2CustomRPCFunction `json:"input" binding:"required"`
+}
+
+type C2CustomRPCFunction struct {
+	C2Profile    string                 `json:"c2_profile" binding:"required"`
+	FunctionName string                 `json:"function_name" binding:"required"`
+	Arguments    map[string]interface{} `json:"arguments"`
+}
+
+type C2CustomRPCFunctionResponse struct {
+	Status string                 `json:"status"`
+	Error  string                 `json:"error"`
+	Result map[string]interface{} `json:"result"`
+}
+
+func C2ProfileCustomRPCFunctionWebhook(c *gin.Context) {
+	var input C2CustomRPCFunctionInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		logging.LogError(err, "Failed to parse out required parameters")
+		c.JSON(http.StatusOK, C2CustomRPCFunctionResponse{
+			Status: "error",
+			Error:  err.Error(),
+		})
+		return
+	}
+	args := input.Input.Arguments
+	if args == nil {
+		args = map[string]interface{}{}
+	}
+	rpcResponse, err := rabbitmq.RabbitMQConnection.SendC2RPCOtherService(rabbitmq.C2OtherServiceRPCMessage{
+		ServiceName:                 input.Input.C2Profile,
+		ServiceRPCFunction:          input.Input.FunctionName,
+		ServiceRPCFunctionArguments: args,
+	})
+	if err != nil {
+		logging.LogError(err, "Failed to send custom RPC to c2 profile",
+			"c2_profile", input.Input.C2Profile, "function", input.Input.FunctionName)
+		c.JSON(http.StatusOK, C2CustomRPCFunctionResponse{
+			Status: "error",
+			Error:  err.Error(),
+		})
+		return
+	}
+	if !rpcResponse.Success {
+		c.JSON(http.StatusOK, C2CustomRPCFunctionResponse{
+			Status: "error",
+			Error:  rpcResponse.Error,
+			Result: rpcResponse.Result,
+		})
+		return
+	}
+	c.JSON(http.StatusOK, C2CustomRPCFunctionResponse{
+		Status: "success",
+		Result: rpcResponse.Result,
+	})
+}

--- a/mythic-docker/src/webserver/initialize.go
+++ b/mythic-docker/src/webserver/initialize.go
@@ -307,6 +307,11 @@ func setRoutes(r *gin.Engine) {
 						mythicjwt.SCOPE_PAYLOAD_READ,
 					}),
 					webcontroller.C2ProfileSampleMessageWebhook)
+				allOperationMembers.POST("c2_custom_rpc_function_webhook",
+					authentication.TokenScopeMiddleware([]string{
+						mythicjwt.SCOPE_PAYLOAD_READ,
+					}),
+					webcontroller.C2ProfileCustomRPCFunctionWebhook)
 				// file
 				allOperationMembers.POST("download_bulk_webhook",
 					authentication.TokenScopeMiddleware([]string{


### PR DESCRIPTION
**Summary**
This branch enhances C2 profile build parameter configuration in the payload creation flow. It adds richer C2 parameter metadata, a schema-driven visual/source config editor for string config parameters, and UI polish around parameter grouping and configuration summaries.

**Key Changes**
- Added first-class C2 profile parameter metadata: `display_name`, `group_name`, `choices_display_names`, and `form_schema`.
- Updated DB schema/migrations, Hasura metadata, Go structs, and C2 sync handling so C2 containers can publish those fields.
- Added a Hasura action + webserver/RabbitMQ path for `c2CustomRPCFunction`, used by the UI to fetch preset/generated config content from C2 services.
- Added an inline config editor for string parameters using `ui:config_editor` format hints, with Ace source editing, JSON/TOML upload, copy/clear, presets, and optional schema-driven visual editing.
- Added `SchemaFormRenderer` for `form_schema` configs, supporting objects, arrays, enums, booleans, string maps, conditional visibility via `show_when`, conditional placeholders, and collapsible nested sections.
- Improved Create Payload UX: card-based parameter rows, collapsible parameter groups, collapsible configuration summary panes, clearer display labels, fixed choice label rendering, and corrected modified/changed indicators.
- Preserved raw parameter values while rendering friendlier labels from `choices_display_names`.
- Fixed invalid button nesting in C2 profile tab close controls and a preset select label overlap.

**Reviewer Notes**
- The main behavioral surface is `MythicReactUI/src/components/pages/CreatePayload/CreatePayloadParameter.js` and `SchemaFormRenderer.js`.
- Backend changes are mostly plumbing for the new C2 metadata fields plus `c2CustomRPCFunction`.
- Hasura permissions were updated in split metadata, since upstream removed the legacy monolithic `tables.yaml`.