### PR TITLE
Attach created file to file browser

### DIFF
--- a/mythic-docker/src/rabbitmq/recv_mythic_rpc_file_create.go
+++ b/mythic-docker/src/rabbitmq/recv_mythic_rpc_file_create.go
@@ -30,6 +30,7 @@ type MythicRPCFileCreateMessage struct {
 	RemotePathOnTarget  string `json:"remote_path"`
 	TargetHostName      string `json:"host"`
 	Comment             string `json:"comment"`
+	FileBrowserID       int    `json:"file_browser_id"`
 }
 type MythicRPCFileCreateMessageResponse struct {
 	Success     bool   `json:"success"`
@@ -92,6 +93,11 @@ func MythicRPCFileCreate(input MythicRPCFileCreateMessage) MythicRPCFileCreateMe
 	fileData.Md5 = fmt.Sprintf("%x", md5Sum)
 	if len(input.Filename) != 0 {
 		fileData.Filename = []byte(input.Filename)
+	}
+
+	if input.FileBrowserID > 0 {
+		fileData.MythicTreeID.Valid = true
+		fileData.MythicTreeID.Int64 = int64(input.FileBrowserID)
 	}
 
 	if input.TaskID > 0 {
@@ -185,8 +191,8 @@ func MythicRPCFileCreate(input MythicRPCFileCreateMessage) MythicRPCFileCreateMe
 		return response
 	}
 	if statement, err := database.DB.PrepareNamed(`INSERT INTO filemeta 
-			(filename,total_chunks,chunks_received,chunk_size,path,operation_id,complete,comment,operator_id,delete_after_fetch,md5,sha1,agent_file_id,full_remote_path,task_id,is_screenshot,is_download_from_agent,host,size)
-			VALUES (:filename, :total_chunks, :chunks_received, :chunk_size, :path, :operation_id, :complete, :comment, :operator_id, :delete_after_fetch, :md5, :sha1, :agent_file_id, :full_remote_path, :task_id, :is_screenshot, :is_download_from_agent, :host, :size)
+			(filename,total_chunks,chunks_received,chunk_size,path,operation_id,complete,comment,operator_id,delete_after_fetch,md5,sha1,agent_file_id,full_remote_path,task_id,is_screenshot,is_download_from_agent,host,size,mythictree_id)
+			VALUES (:filename, :total_chunks, :chunks_received, :chunk_size, :path, :operation_id, :complete, :comment, :operator_id, :delete_after_fetch, :md5, :sha1, :agent_file_id, :full_remote_path, :task_id, :is_screenshot, :is_download_from_agent, :host, :size, :mythictree_id)
 			RETURNING id`); err != nil {
 		logging.LogError(err, "Failed to save file metadata to database")
 		response.Error = err.Error()

--- a/mythic-docker/src/rabbitmq/recv_mythic_rpc_filebrowser_create.go
+++ b/mythic-docker/src/rabbitmq/recv_mythic_rpc_filebrowser_create.go
@@ -16,6 +16,7 @@ type MythicRPCFileBrowserCreateMessage struct {
 type MythicRPCFileBrowserCreateMessageResponse struct {
 	Success bool   `json:"success"`
 	Error   string `json:"error"`
+	NodeId  int    `json:"node_id"`
 }
 type MythicRPCFileBrowserCreateFileBrowserData = agentMessagePostResponseFileBrowser
 
@@ -52,19 +53,20 @@ func MythicRPCFileBrowserCreate(input MythicRPCFileBrowserCreateMessage) MythicR
 		response.Error = err.Error()
 		return response
 	}
-	err = HandleAgentMessagePostResponseFileBrowser(task, &input.FileBrowser, int(task.APITokensID.Int64))
+	id, err := HandleAgentMessagePostResponseFileBrowser(task, &input.FileBrowser, int(task.APITokensID.Int64))
 	if err != nil {
 		logging.LogError(err, "Failed to create files in MythicRPCFileBrowserCreate")
 		response.Error = err.Error()
 		return response
 	}
-	err = HandleAgentMessagePostResponseFileBrowser(task, nil, int(task.APITokensID.Int64))
+	_, err = HandleAgentMessagePostResponseFileBrowser(task, nil, int(task.APITokensID.Int64))
 	if err != nil {
 		logging.LogError(err, "Failed to flush files in MythicRPCFileBrowserCreate")
 		response.Error = err.Error()
 		return response
 	}
 	response.Success = true
+	response.NodeId = id
 	return response
 }
 func processMythicRPCFileBrowserCreate(msg amqp.Delivery) interface{} {

--- a/mythic-docker/src/rabbitmq/util_agent_message_actions_post_response.go
+++ b/mythic-docker/src/rabbitmq/util_agent_message_actions_post_response.go
@@ -1802,7 +1802,7 @@ func listenForFileBrowserData() {
 		case message := <-FileBrowserChannel:
 			//logging.LogInfo("[*] got message from FileBrowserChannel", "task", message.Task.ID, "completed", message.Task.Completed,
 			//	"nil data", message.NewFileBrowserData == nil)
-			err := HandleAgentMessagePostResponseFileBrowser(*message.Task, message.NewFileBrowserData, message.APITokenID)
+			_, err := HandleAgentMessagePostResponseFileBrowser(*message.Task, message.NewFileBrowserData, message.APITokenID)
 			if err != nil {
 				logging.LogError(err, "Failed to handle file browser post response")
 			}
@@ -1810,7 +1810,7 @@ func listenForFileBrowserData() {
 	}
 }
 func HandleAgentMessagePostResponseFileBrowser(task databaseStructs.Task, fileBrowser *agentMessagePostResponseFileBrowser,
-	apitokensId int) error {
+	apitokensId int) (int, error) {
 	// given a FileBrowser object, need to insert it into database and potentially insert parents along the way
 	if fileBrowser == nil {
 		fileBrowserUpdateDeletedChannel <- FileBrowserChannelMessage{
@@ -1818,7 +1818,7 @@ func HandleAgentMessagePostResponseFileBrowser(task databaseStructs.Task, fileBr
 			NewFileBrowserData: fileBrowser,
 			APITokenID:         apitokensId,
 		}
-		return nil
+		return 0, nil
 	}
 	if fileBrowser.SetAsUserOutput != nil && *fileBrowser.SetAsUserOutput {
 		go func(fileBrowserForOutput *agentMessagePostResponseFileBrowser) {
@@ -1838,7 +1838,7 @@ func HandleAgentMessagePostResponseFileBrowser(task databaseStructs.Task, fileBr
 	if err != nil {
 		logging.LogError(err, "Failed to add data for file browser due to path issue")
 		go SendAllOperationsMessage(err.Error(), task.OperationID, "", database.MESSAGE_LEVEL_AGENT_MESSGAGE, true)
-		return err
+		return 0, err
 	}
 	if pathData.Host == "" {
 		pathData.Host = strings.ToUpper(task.Callback.Host)
@@ -1857,7 +1857,7 @@ func HandleAgentMessagePostResponseFileBrowser(task databaseStructs.Task, fileBr
 	}
 	if fileBrowser.Name == "" {
 		logging.LogError(nil, "Can't create file browser entry with empty name")
-		return errors.New("can't make file browser entry with empty name")
+		return 0, errors.New("can't make file browser entry with empty name")
 	}
 	fullPath := treeNodeGetFullPath(
 		[]byte(realParentPath),
@@ -1928,7 +1928,7 @@ func HandleAgentMessagePostResponseFileBrowser(task databaseStructs.Task, fileBr
 			createTreeNode(&newTreeChild)
 		}
 	}
-	return nil
+	return newTree.ID, nil
 }
 func listenForFileBrowserUpdateDeleted() {
 	fileBrowserUpdateDeletedCache := make(map[int][]*agentMessagePostResponseFileBrowser)

--- a/mythic-docker/src/webserver/controllers/mythictree_create_webhook.go
+++ b/mythic-docker/src/webserver/controllers/mythictree_create_webhook.go
@@ -70,7 +70,7 @@ func MythictreeCreateWebhook(c *gin.Context) {
 		return
 	}
 	if input.Input.FileBrowser != nil {
-		err = rabbitmq.HandleAgentMessagePostResponseFileBrowser(task, input.Input.FileBrowser, apitokenId)
+		_, err = rabbitmq.HandleAgentMessagePostResponseFileBrowser(task, input.Input.FileBrowser, apitokenId)
 		if err != nil {
 			c.JSON(http.StatusOK, gin.H{
 				"status": "error",
@@ -78,7 +78,7 @@ func MythictreeCreateWebhook(c *gin.Context) {
 			})
 			return
 		}
-		err = rabbitmq.HandleAgentMessagePostResponseFileBrowser(task, nil, apitokenId)
+		_, err = rabbitmq.HandleAgentMessagePostResponseFileBrowser(task, nil, apitokenId)
 		if err != nil {
 			c.JSON(http.StatusOK, gin.H{
 				"status": "error",


### PR DESCRIPTION
Enhanced MythicRPCFileCreate to allow creating files in the file browser with previewable content. This is particularly helpful for workflows like adding files during the process_response method.

* Added an option to SendMythicRPCFileCreate to attach a new file directly to the file browser.
* Updated SendMythicRPCFileBrowserCreate to return the resulting file ID.