### PR TITLE
Fix file handle leak in bulk download webhook

### DIFF
--- a/mythic-docker/src/webserver/controllers/file_download_bulk_webhook.go
+++ b/mythic-docker/src/webserver/controllers/file_download_bulk_webhook.go
@@ -104,6 +104,7 @@ func DownloadBulkFilesWebhook(c *gin.Context) {
 		newFileName := fmt.Sprintf("%s_%s_%s%s", hostName, justFileName, filemeta.AgentFileID, justFileExtension)
 		fileWriter, err := zipWriter.Create(newFileName)
 		if err != nil {
+			file.Close()
 			logging.LogError(err, "Failed to create file entry in zip")
 			c.JSON(http.StatusOK, DownloadBulkFilesResponse{
 				Status: "error",
@@ -112,6 +113,7 @@ func DownloadBulkFilesWebhook(c *gin.Context) {
 			return
 		}
 		_, err = io.Copy(fileWriter, file)
+		file.Close()
 		if err != nil {
 			logging.LogError(err, "Failed to write file entry in zip")
 			c.JSON(http.StatusOK, DownloadBulkFilesResponse{


### PR DESCRIPTION
## Motivation

The DownloadBulkFilesWebhook function opens files in a loop but never closes them, causing file descriptor leaks. When processing large batches of files, this can exhaust system resources and cause the application to crash.

## Changes

- Added explicit file.Close() calls after os.Open() in the loop
- Ensured files are closed in all error paths and after successful io.Copy()
- Avoided defer since it would delay closing until function return in loops, which was the original issue identified in PR #571

## Testing

- [x] Code compiles without errors
- [x] File handles are properly closed in all code paths
- [x] No resource leaks when processing multiple files

## Checklist

- [x] Code follows the project coding standards
- [x] Changes are minimal and focused on the specific issue
- [x] Commit messages follow conventional format
- [x] No unrelated changes included

This is a follow-up to PR #571, addressing the same pattern of file handle leaks in loops.