### PR TITLE
Fix task output export filename race

### DIFF
--- a/MythicReactUI/src/components/pages/Callbacks/TaskDisplayContainer.js
+++ b/MythicReactUI/src/components/pages/Callbacks/TaskDisplayContainer.js
@@ -21,7 +21,7 @@ import ConfirmationNumberIcon from '@mui/icons-material/ConfirmationNumber';
 import {TaskTokenDialog} from './TaskTokenDialog';
 import Grid from '@mui/material/Grid';
 import ReplayIcon from '@mui/icons-material/Replay';
-import {gql, useMutation, useLazyQuery } from '@apollo/client';
+import {gql, useApolloClient, useMutation } from '@apollo/client';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faExclamationTriangle} from '@fortawesome/free-solid-svg-icons';
 import { faExternalLinkAlt, faExpandArrowsAlt } from '@fortawesome/free-solid-svg-icons';
@@ -41,6 +41,7 @@ import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import {EventTriggerContextSelectDialog} from "../Eventing/EventTriggerContextSelect";
 import PlayCircleFilledTwoToneIcon from '@mui/icons-material/PlayCircleFilledTwoTone';
+import {prepareTaskOutputDownload} from './TaskOutputDownload';
 
 const ReissueTaskMutationGQL = gql`
 mutation reissueTaskMutation($task_id: Int!){
@@ -58,13 +59,22 @@ mutation reissueTaskHandlerMutation($task_id: Int!){
   }
 }
 `;
-const getAllResponsesLazyQuery = gql`
-query subResponsesQuery($task_id: Int!) {
-  response(where: {task_id: {_eq: $task_id}}, order_by: {id: asc}) {
-    id
-    response: response_text
-  }
-}`;
+const useTaskOutputDownload = () => {
+    const client = useApolloClient();
+    return React.useCallback(async taskID => {
+        try{
+            const {filename, output} = await prepareTaskOutputDownload({
+                client,
+                taskID,
+                decodeResponse: b64DecodeUnicode
+            });
+            downloadFileFromMemory(output, filename);
+        }catch(error){
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            snackActions.error("Failed to download task output: " + errorMessage);
+        }
+    }, [client]);
+};
 
 export const TaskDisplayContainer = ({task, me}) => {
     const [viewBrowserScript, setViewBrowserScript] = React.useState(true);
@@ -197,23 +207,12 @@ const SideDisplayGeneric = ({toggleViewBrowserScript, toggleSelectAllOutput,
     const [openTokenDialog, setOpenTokenDialog] = React.useState(false);
     const [openStdoutStderrDialog, setOpenStdoutStderrDialog] = React.useState(false);
     const [openOpsecDialog, setOpenOpsecDialog] = React.useState({open: false, view: "pre"});
-    const [downloadResponses] = useLazyQuery(getAllResponsesLazyQuery, {
-        fetchPolicy: "network-only",
-        onCompleted: (data) => {
-            const output = data.response.reduce( (prev, cur) => {
-                return prev + b64DecodeUnicode(cur.response);
-            }, b64DecodeUnicode(""));
-            downloadFileFromMemory(output, "task_" + task.id + ".txt");
-        },
-        onError: (data) => {
-
-        }
-    });
+    const downloadTaskOutput = useTaskOutputDownload();
     React.useEffect( () => {
         setTask(taskData);
     }, [taskData.id, taskData.token, taskData.original_params, taskData.opsec_pre_blocked, taskData.opsec_pre_bypassed, taskData.opsec_post_blocked, taskData.opsec_post_bypassed])
     const onDownloadResponses = () => {
-        downloadResponses({variables: {task_id: task.id}});
+        downloadTaskOutput(taskData.id);
     };
     const copyToClipboard = () => {
         let command = task?.command?.cmd || task.command_name;
@@ -463,23 +462,12 @@ const SpeedDialDisplayGeneric = ({toggleViewBrowserScript, toggleSelectAllOutput
   const [openTokenDialog, setOpenTokenDialog] = React.useState(false);
   const [openStdoutStderrDialog, setOpenStdoutStderrDialog] = React.useState(false);
   const [openOpsecDialog, setOpenOpsecDialog] = React.useState({open: false, view: "pre"});
-  const [downloadResponses] = useLazyQuery(getAllResponsesLazyQuery, {
-    fetchPolicy: "network-only",
-    onCompleted: (data) => {
-      const output = data.response.reduce( (prev, cur) => {
-        return prev + b64DecodeUnicode(cur.response);
-      }, b64DecodeUnicode(""));
-      downloadFileFromMemory(output, "task_" + task.id + ".txt");
-    },
-    onError: (data) => {
-
-    }
-  });
+  const downloadTaskOutput = useTaskOutputDownload();
   React.useEffect( () => {
     setTask(taskData);
   }, [taskData.id, taskData.token, taskData.original_params, taskData.opsec_pre_blocked, taskData.opsec_pre_bypassed, taskData.opsec_post_blocked, taskData.opsec_post_bypassed])
   const onDownloadResponses = () => {
-    downloadResponses({variables: {task_id: task.id}});
+    downloadTaskOutput(taskData.id);
     setOpenSpeedDial(false);
   };
   const copyToClipboard = () => {

--- a/MythicReactUI/src/components/pages/Callbacks/TaskOutputDownload.js
+++ b/MythicReactUI/src/components/pages/Callbacks/TaskOutputDownload.js
@@ -1,0 +1,37 @@
+import {gql} from '@apollo/client';
+
+export const getAllTaskResponsesQuery = gql`
+query taskOutputDownloadQuery($task_id: Int!) {
+  response(where: {task_id: {_eq: $task_id}}, order_by: {id: asc}) {
+    id
+    task_id
+    response: response_text
+  }
+}`;
+
+export const prepareTaskOutputDownload = async ({client, taskID, decodeResponse}) => {
+    if(!Number.isInteger(taskID)){
+        throw new Error("Task output download requires a valid task ID");
+    }
+    if(typeof decodeResponse !== "function"){
+        throw new Error("Task output download requires a response decoder");
+    }
+    const {data} = await client.query({
+        query: getAllTaskResponsesQuery,
+        variables: {task_id: taskID},
+        fetchPolicy: "network-only"
+    });
+    if(!Array.isArray(data?.response)){
+        throw new Error("Task output query returned an invalid response");
+    }
+    const output = data.response.reduce((previous, current) => {
+        if(current.task_id !== taskID){
+            throw new Error(`Task output query returned data for task ${current.task_id} instead of task ${taskID}`);
+        }
+        return previous + decodeResponse(current.response);
+    }, decodeResponse(""));
+    return {
+        filename: `task_${taskID}.txt`,
+        output
+    };
+};

--- a/MythicReactUI/src/components/pages/Callbacks/TaskOutputDownload.test.js
+++ b/MythicReactUI/src/components/pages/Callbacks/TaskOutputDownload.test.js
@@ -1,0 +1,51 @@
+import {getAllTaskResponsesQuery, prepareTaskOutputDownload} from './TaskOutputDownload';
+
+const prepare = (client, taskID) => prepareTaskOutputDownload({
+    client,
+    taskID,
+    decodeResponse: value => value
+});
+const response = (taskID, text, id = 1) => ({id, task_id: taskID, response: text});
+const deferred = () => {
+    let resolve;
+    const promise = new Promise(resolvePromise => { resolve = resolvePromise; });
+    return {promise, resolve};
+};
+
+describe('prepareTaskOutputDownload', () => {
+    test('queries and names output with the requested task ID', async () => {
+        const client = {query: jest.fn().mockResolvedValue({
+            data: {response: [response(33, 'first'), response(33, ' second', 2)]}
+        })};
+
+        await expect(prepare(client, 33)).resolves.toEqual({
+            filename: 'task_33.txt',
+            output: 'first second'
+        });
+        expect(client.query).toHaveBeenCalledWith({
+            query: getAllTaskResponsesQuery,
+            variables: {task_id: 33},
+            fetchPolicy: 'network-only'
+        });
+    });
+
+    test('keeps overlapping exports associated with their initiating tasks', async () => {
+        const requests = {33: deferred(), 35: deferred()};
+        const client = {query: jest.fn(({variables}) => requests[variables.task_id].promise)};
+        const exports = {33: prepare(client, 33), 35: prepare(client, 35)};
+
+        requests[35].resolve({data: {response: [response(35, 'task 35')]}});
+        await expect(exports[35]).resolves.toEqual({filename: 'task_35.txt', output: 'task 35'});
+
+        requests[33].resolve({data: {response: [response(33, 'task 33')]}});
+        await expect(exports[33]).resolves.toEqual({filename: 'task_33.txt', output: 'task 33'});
+    });
+
+    test.each([
+        ['another task', {data: {response: [response(35, 'wrong task')]}}, 'task 35 instead of task 33'],
+        ['a malformed result', {data: undefined}, 'invalid response']
+    ])('rejects output from %s', async (_case, result, expectedError) => {
+        const client = {query: jest.fn().mockResolvedValue(result)};
+        await expect(prepare(client, 33)).rejects.toThrow(expectedError);
+    });
+});


### PR DESCRIPTION
## Summary

- bind task response exports to the task that initiated the request
- use an isolated Apollo client query for each export
- verify returned response rows belong to the requested task before generating `task_<id>.txt`
- surface query and validation failures instead of silently discarding them
- add focused coverage for normal, overlapping, mismatched, and malformed results

## Problem

The **Download output** action queried responses using the selected task ID, but its asynchronous completion callback generated the filename using the component's current task state. If the selected task changed while the query was in flight, output from task A could be saved as `task_B.txt`.

This affects exported textual task responses, such as shell output. It does not affect files transferred by an agent download task.

## Test plan

- `CI=true npm run react-test -- --watchAll=false --runInBand TaskOutputDownload.test.js`
  - 4 tests passed
- `npm run build`
  - production build passed with pre-existing unrelated lint warnings

Interactive race testing in a running Mythic instance remains to be completed.
