### PR TITLE
fix(cli): fail fast on docker-compose failures in mythic-cli start

### DIFF
--- a/Mythic_CLI/src/cmd/manager/dockerComposeManager.go
+++ b/Mythic_CLI/src/cmd/manager/dockerComposeManager.go
@@ -1413,7 +1413,7 @@ func (d *DockerComposeManager) runDockerCompose(args []string) error {
 			return err
 		}
 		if processState.ExitCode() != 0 {
-			return err
+			return fmt.Errorf("docker-compose %v exited with code %d", args, processState.ExitCode())
 		}
 	}
 	return nil

--- a/Mythic_CLI/src/cmd/start.go
+++ b/Mythic_CLI/src/cmd/start.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/MythicMeta/Mythic_CLI/cmd/config"
 	"github.com/MythicMeta/Mythic_CLI/cmd/internal"
 	"github.com/spf13/cobra"
@@ -31,6 +33,6 @@ func start(cmd *cobra.Command, args []string) {
 		keepVolume = !config.GetMythicEnv().GetBool("REBUILD_ON_START")
 	}
 	if err := internal.ServiceStart(args, localKeepVolume); err != nil {
-
+		log.Fatalf("[-] Failed to start Mythic: %v\n", err)
 	}
 }


### PR DESCRIPTION
Two swallowed-error bugs let start march past a failed docker compose up into the UI health-probe loop, ending with os.Exit(1) and misleading remediation advice instead of the real compose failure. This annoyed me while making my other two fixes, so here you go 💖

- DockerComposeManager.runDockerCompose (pty path): on nonzero exit it returned the outer err variable — which is nil — instead of the failure. Now returns a descriptive error including exit code.
- start: if err := internal.ServiceStart(...); err != nil {} discarded the error entirely. Now log.Fatalf so failures surface immediately with the actual compose error.

Observed on a host where a stale depends_on made the project invalid: the CLI printed the compose error inline, then spent ~100s retrying https://…/new/login before exiting — masking the root cause.
