### PR TITLE
Generalized Support for external services across compose generation and port checks

### DIFF
--- a/Mythic_CLI/src/cmd/config/env.go
+++ b/Mythic_CLI/src/cmd/config/env.go
@@ -271,6 +271,9 @@ If it's anything else, mythic-cli will not spin up this container as it assumes 
 	mythicEnv.SetDefault("postgres_password", utils.GenerateRandomPassword(30))
 	mythicEnvInfo["postgres_password"] = `This is the randomly generated password that mythic_server and mythic_graphql use to connect to the mythic_postgres container`
 
+	mythicEnv.SetDefault("postgres_sslmode", "disable")
+	mythicEnvInfo["postgres_sslmode"] = `This specifies the SSL mode used when connecting to the PostgreSQL database (e.g. disable, require, verify-ca, verify-full)`
+
 	mythicEnv.SetDefault("postgres_cpus", defaultNumberOfCPUs)
 	mythicEnvInfo["postgres_cpus"] = `Set this to limit the maximum number of CPUs this service is able to consume`
 

--- a/Mythic_CLI/src/cmd/internal/serviceExecution.go
+++ b/Mythic_CLI/src/cmd/internal/serviceExecution.go
@@ -87,8 +87,14 @@ func ServiceStart(containers []string, keepVolume bool) error {
 		log.Printf("[-] Failed to remove images\n%v\n", err)
 		return err
 	}
-	updateNginxBlockLists()
-	generateCerts()
+	// nginx-specific housekeeping only applies when mythic_nginx runs locally
+	if isNginxInternal() {
+		updateNginxBlockLists()
+		if err := generateCerts(); err != nil {
+			log.Printf("[-] Failed to generate certs: %v\n", err)
+			return err
+		}
+	}
 	TestMythicRabbitmqConnection()
 	TestMythicConnection()
 	Status(false)

--- a/Mythic_CLI/src/cmd/internal/serviceExecution.go
+++ b/Mythic_CLI/src/cmd/internal/serviceExecution.go
@@ -88,7 +88,7 @@ func ServiceStart(containers []string, keepVolume bool) error {
 		return err
 	}
 	// nginx-specific housekeeping only applies when mythic_nginx runs locally
-	if isNginxInternal() {
+	if isServiceInternal("mythic_nginx") {
 		updateNginxBlockLists()
 		if err := generateCerts(); err != nil {
 			log.Printf("[-] Failed to generate certs: %v\n", err)

--- a/Mythic_CLI/src/cmd/internal/serviceMetadata.go
+++ b/Mythic_CLI/src/cmd/internal/serviceMetadata.go
@@ -67,19 +67,7 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			extraHosts := []string{
-				"mythic_server:127.0.0.1",
-				"mythic_rabbitmq:127.0.0.1",
-				"mythic_react:127.0.0.1",
-				"mythic_documentation:127.0.0.1",
-				"mythic_graphql:127.0.0.1",
-				"mythic_jupyter:127.0.0.1",
-				"mythic_postgres:127.0.0.1",
-			}
-			if isNginxInternal() {
-				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
-			}
-			pStruct["extra_hosts"] = extraHosts
+			pStruct["extra_hosts"] = getExtraHosts()
 			if mythicEnv.GetBool("postgres_bind_localhost_only") {
 				pStruct["command"] = "postgres -c \"max_connections=100\" -p ${POSTGRES_PORT} -c config_file=/etc/postgresql.conf -c \"listen_addresses=localhost\""
 			} else {
@@ -149,19 +137,7 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			extraHosts := []string{
-				"mythic_server:127.0.0.1",
-				"mythic_rabbitmq:127.0.0.1",
-				"mythic_react:127.0.0.1",
-				"mythic_documentation:127.0.0.1",
-				"mythic_graphql:127.0.0.1",
-				"mythic_jupyter:127.0.0.1",
-				"mythic_postgres:127.0.0.1",
-			}
-			if isNginxInternal() {
-				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
-			}
-			pStruct["extra_hosts"] = extraHosts
+			pStruct["extra_hosts"] = getExtraHosts()
 			if mythicEnv.GetBool("documentation_bind_localhost_only") {
 				pStruct["environment"] = []string{
 					"DOCUMENTATION_PORT=${DOCUMENTATION_PORT}",
@@ -191,17 +167,22 @@ func AddMythicService(service string, removeVolume bool) {
 			}
 		}
 	case "mythic_graphql":
-		dependsOn := map[string]map[string]string{
-			"mythic_server": {
+		dependsOn := map[string]map[string]string{}
+		if isServiceInternal("mythic_server") {
+			dependsOn["mythic_server"] = map[string]string{
 				"condition": "service_healthy",
-			},
+			}
 		}
-		if isPostgresInternal() {
+		if isServiceInternal("mythic_postgres") {
 			dependsOn["mythic_postgres"] = map[string]string{
 				"condition": "service_healthy",
 			}
 		}
-		pStruct["depends_on"] = dependsOn
+		if len(dependsOn) > 0 {
+			pStruct["depends_on"] = dependsOn
+		} else {
+			delete(pStruct, "depends_on")
+		}
 		if mythicEnv.GetBool("hasura_use_build_context") {
 			pStruct["build"] = map[string]interface{}{
 				"context": "./hasura-docker",
@@ -248,19 +229,7 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			extraHosts := []string{
-				"mythic_server:127.0.0.1",
-				"mythic_rabbitmq:127.0.0.1",
-				"mythic_react:127.0.0.1",
-				"mythic_documentation:127.0.0.1",
-				"mythic_graphql:127.0.0.1",
-				"mythic_jupyter:127.0.0.1",
-				"mythic_postgres:127.0.0.1",
-			}
-			if isNginxInternal() {
-				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
-			}
-			pStruct["extra_hosts"] = extraHosts
+			pStruct["extra_hosts"] = getExtraHosts()
 			if mythicEnv.GetBool("hasura_bind_localhost_only") {
 				environment = append(environment, "HASURA_GRAPHQL_SERVER_HOST=127.0.0.1")
 			} else {
@@ -276,22 +245,36 @@ func AddMythicService(service string, removeVolume bool) {
 			delete(pStruct, "volumes")
 		}
 	case "mythic_nginx":
-		pStruct["depends_on"] = map[string]map[string]string{
-			"mythic_server": {
+		dependsOn := map[string]map[string]string{}
+		if isServiceInternal("mythic_server") {
+			dependsOn["mythic_server"] = map[string]string{
 				"condition": "service_healthy",
-			},
-			"mythic_react": {
+			}
+		}
+		if isServiceInternal("mythic_react") {
+			dependsOn["mythic_react"] = map[string]string{
 				"condition": "service_started",
-			},
-			"mythic_jupyter": {
+			}
+		}
+		if isServiceInternal("mythic_jupyter") {
+			dependsOn["mythic_jupyter"] = map[string]string{
 				"condition": "service_healthy",
-			},
-			"mythic_documentation": {
+			}
+		}
+		if isServiceInternal("mythic_documentation") {
+			dependsOn["mythic_documentation"] = map[string]string{
 				"condition": "service_started",
-			},
-			"mythic_graphql": {
+			}
+		}
+		if isServiceInternal("mythic_graphql") {
+			dependsOn["mythic_graphql"] = map[string]string{
 				"condition": "service_healthy",
-			},
+			}
+		}
+		if len(dependsOn) > 0 {
+			pStruct["depends_on"] = dependsOn
+		} else {
+			delete(pStruct, "depends_on")
 		}
 		if mythicEnv.GetBool("nginx_use_build_context") {
 			pStruct["build"] = map[string]interface{}{
@@ -360,19 +343,7 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			extraHosts := []string{
-				"mythic_server:127.0.0.1",
-				"mythic_rabbitmq:127.0.0.1",
-				"mythic_react:127.0.0.1",
-				"mythic_documentation:127.0.0.1",
-				"mythic_graphql:127.0.0.1",
-				"mythic_jupyter:127.0.0.1",
-				"mythic_postgres:127.0.0.1",
-			}
-			if isNginxInternal() {
-				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
-			}
-			pStruct["extra_hosts"] = extraHosts
+			pStruct["extra_hosts"] = getExtraHosts()
 			if mythicEnv.GetBool("nginx_bind_localhost_only") {
 				finalNginxEnv = append(finalNginxEnv, "NGINX_BIND_IPV4=127.0.0.1", "NGINX_BIND_IPV6=[::1]")
 			} else {
@@ -449,19 +420,7 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			extraHosts := []string{
-				"mythic_server:127.0.0.1",
-				"mythic_rabbitmq:127.0.0.1",
-				"mythic_react:127.0.0.1",
-				"mythic_documentation:127.0.0.1",
-				"mythic_graphql:127.0.0.1",
-				"mythic_jupyter:127.0.0.1",
-				"mythic_postgres:127.0.0.1",
-			}
-			if isNginxInternal() {
-				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
-			}
-			pStruct["extra_hosts"] = extraHosts
+			pStruct["extra_hosts"] = getExtraHosts()
 			if mythicEnv.GetBool("rabbitmq_bind_localhost_only") {
 				environment = append(environment, "RABBITMQ_NODE_IP_ADDRESS=127.0.0.1", "RABBITMQ_NODE_PORT=${RABBITMQ_PORT}")
 			} else {
@@ -487,20 +446,27 @@ func AddMythicService(service string, removeVolume bool) {
 			}
 		}
 	case "mythic_react":
-		dependsOn := map[string]map[string]string{
-			"mythic_server": {
+		dependsOn := map[string]map[string]string{}
+		if isServiceInternal("mythic_server") {
+			dependsOn["mythic_server"] = map[string]string{
 				"condition": "service_healthy",
-			},
-			"mythic_graphql": {
-				"condition": "service_healthy",
-			},
+			}
 		}
-		if isPostgresInternal() {
+		if isServiceInternal("mythic_graphql") {
+			dependsOn["mythic_graphql"] = map[string]string{
+				"condition": "service_healthy",
+			}
+		}
+		if isServiceInternal("mythic_postgres") {
 			dependsOn["mythic_postgres"] = map[string]string{
 				"condition": "service_healthy",
 			}
 		}
-		pStruct["depends_on"] = dependsOn
+		if len(dependsOn) > 0 {
+			pStruct["depends_on"] = dependsOn
+		} else {
+			delete(pStruct, "depends_on")
+		}
 		if mythicEnv.GetBool("mythic_react_debug") {
 			pStruct["build"] = map[string]interface{}{
 				"context": "./MythicReactUI",
@@ -571,19 +537,7 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			extraHosts := []string{
-				"mythic_server:127.0.0.1",
-				"mythic_rabbitmq:127.0.0.1",
-				"mythic_react:127.0.0.1",
-				"mythic_documentation:127.0.0.1",
-				"mythic_graphql:127.0.0.1",
-				"mythic_jupyter:127.0.0.1",
-				"mythic_postgres:127.0.0.1",
-			}
-			if isNginxInternal() {
-				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
-			}
-			pStruct["extra_hosts"] = extraHosts
+			pStruct["extra_hosts"] = getExtraHosts()
 			if mythicEnv.GetBool("mythic_react_bind_localhost_only") {
 				pStruct["environment"] = []string{
 					"MYTHIC_REACT_PORT=${MYTHIC_REACT_PORT}",
@@ -598,20 +552,27 @@ func AddMythicService(service string, removeVolume bool) {
 		}
 
 	case "mythic_jupyter":
-		dependsOn := map[string]map[string]string{
-			"mythic_server": {
+		dependsOn := map[string]map[string]string{}
+		if isServiceInternal("mythic_server") {
+			dependsOn["mythic_server"] = map[string]string{
 				"condition": "service_healthy",
-			},
-			"mythic_graphql": {
-				"condition": "service_healthy",
-			},
+			}
 		}
-		if isPostgresInternal() {
+		if isServiceInternal("mythic_graphql") {
+			dependsOn["mythic_graphql"] = map[string]string{
+				"condition": "service_healthy",
+			}
+		}
+		if isServiceInternal("mythic_postgres") {
 			dependsOn["mythic_postgres"] = map[string]string{
 				"condition": "service_healthy",
 			}
 		}
-		pStruct["depends_on"] = dependsOn
+		if len(dependsOn) > 0 {
+			pStruct["depends_on"] = dependsOn
+		} else {
+			delete(pStruct, "depends_on")
+		}
 		if mythicEnv.GetBool("jupyter_use_build_context") {
 			pStruct["build"] = map[string]interface{}{
 				"context": "./jupyter-docker",
@@ -647,19 +608,7 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			extraHosts := []string{
-				"mythic_server:127.0.0.1",
-				"mythic_rabbitmq:127.0.0.1",
-				"mythic_react:127.0.0.1",
-				"mythic_documentation:127.0.0.1",
-				"mythic_graphql:127.0.0.1",
-				"mythic_jupyter:127.0.0.1",
-				"mythic_postgres:127.0.0.1",
-			}
-			if isNginxInternal() {
-				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
-			}
-			pStruct["extra_hosts"] = extraHosts
+			pStruct["extra_hosts"] = getExtraHosts()
 			environment := []string{
 				"JUPYTER_TOKEN=${JUPYTER_TOKEN}",
 				"CHOWN_EXTRA=/projects",
@@ -695,17 +644,22 @@ func AddMythicService(service string, removeVolume bool) {
 			}
 		}
 	case "mythic_server":
-		dependsOn := map[string]map[string]string{
-			"mythic_rabbitmq": {
+		dependsOn := map[string]map[string]string{}
+		if isServiceInternal("mythic_rabbitmq") {
+			dependsOn["mythic_rabbitmq"] = map[string]string{
 				"condition": "service_healthy",
-			},
+			}
 		}
-		if isPostgresInternal() {
+		if isServiceInternal("mythic_postgres") {
 			dependsOn["mythic_postgres"] = map[string]string{
 				"condition": "service_healthy",
 			}
 		}
-		pStruct["depends_on"] = dependsOn
+		if len(dependsOn) > 0 {
+			pStruct["depends_on"] = dependsOn
+		} else {
+			delete(pStruct, "depends_on")
+		}
 		if mythicEnv.GetBool("mythic_server_use_build_context") {
 			pStruct["build"] = map[string]interface{}{
 				"context": "./mythic-docker",
@@ -774,19 +728,7 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			extraHosts := []string{
-				"mythic_server:127.0.0.1",
-				"mythic_rabbitmq:127.0.0.1",
-				"mythic_react:127.0.0.1",
-				"mythic_documentation:127.0.0.1",
-				"mythic_graphql:127.0.0.1",
-				"mythic_jupyter:127.0.0.1",
-				"mythic_postgres:127.0.0.1",
-			}
-			if isNginxInternal() {
-				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
-			}
-			pStruct["extra_hosts"] = extraHosts
+			pStruct["extra_hosts"] = getExtraHosts()
 		}
 
 		if _, ok := pStruct["environment"]; ok {
@@ -811,7 +753,7 @@ func AddMythicService(service string, removeVolume bool) {
 			}
 		}
 	case "mythic_sync":
-		if isNginxInternal() {
+		if isServiceInternal("mythic_nginx") {
 			pStruct["depends_on"] = map[string]map[string]string{
 				"mythic_nginx": {"condition": "service_healthy"},
 			}
@@ -861,19 +803,7 @@ func AddMythicService(service string, removeVolume bool) {
 			delete(pStruct, "extra_hosts")
 		} else {
 			pStruct["network_mode"] = "host"
-			extraHosts := []string{
-				"mythic_server:127.0.0.1",
-				"mythic_rabbitmq:127.0.0.1",
-				"mythic_react:127.0.0.1",
-				"mythic_documentation:127.0.0.1",
-				"mythic_graphql:127.0.0.1",
-				"mythic_jupyter:127.0.0.1",
-				"mythic_postgres:127.0.0.1",
-			}
-			if isNginxInternal() {
-				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
-			}
-			pStruct["extra_hosts"] = extraHosts
+			pStruct["extra_hosts"] = getExtraHosts()
 		}
 
 	}
@@ -905,33 +835,26 @@ func Add3rdPartyService(service string, additionalConfigs map[string]interface{}
 		"args":    config.GetBuildArguments(),
 	}
 	existingConfig["network_mode"] = "host"
-	extraHosts := []string{
-		"mythic_server:127.0.0.1",
-		"mythic_rabbitmq:127.0.0.1",
-		"mythic_react:127.0.0.1",
-		"mythic_documentation:127.0.0.1",
-		"mythic_graphql:127.0.0.1",
-		"mythic_jupyter:127.0.0.1",
-		"mythic_postgres:127.0.0.1",
+	existingConfig["extra_hosts"] = getExtraHosts()
+
+	dependsOn := map[string]map[string]string{}
+	if isServiceInternal("mythic_server") {
+		dependsOn["mythic_server"] = map[string]string{"condition": "service_healthy"}
 	}
-
-	if isNginxInternal() {
-		extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
+	if isServiceInternal("mythic_rabbitmq") {
+		dependsOn["mythic_rabbitmq"] = map[string]string{"condition": "service_healthy"}
 	}
-
-	existingConfig["extra_hosts"] = extraHosts
-
-	dependsOn := map[string]map[string]string{
-		"mythic_server":   {"condition": "service_healthy"},
-		"mythic_rabbitmq": {"condition": "service_healthy"},
-		"mythic_graphql":  {"condition": "service_healthy"},
+	if isServiceInternal("mythic_graphql") {
+		dependsOn["mythic_graphql"] = map[string]string{"condition": "service_healthy"}
 	}
-
-	if isNginxInternal() {
+	if isServiceInternal("mythic_nginx") {
 		dependsOn["mythic_nginx"] = map[string]string{"condition": "service_healthy"}
 	}
-
-	existingConfig["depends_on"] = dependsOn
+	if len(dependsOn) > 0 {
+		existingConfig["depends_on"] = dependsOn
+	} else {
+		delete(existingConfig, "depends_on")
+	}
 	agentConfigs := config.GetConfigStrings([]string{fmt.Sprintf("%s_.*", service)})
 	agentUseBuildContextKey := fmt.Sprintf("%s_use_build_context", service)
 	agentRemoteImageKey := fmt.Sprintf("%s_remote_image", service)
@@ -1049,11 +972,16 @@ func applyImageMirror(imageURL, mirror string) string {
 	return mirror + "/" + imageURL
 }
 
-func isNginxInternal() bool {
-	nginxHost := config.GetMythicEnv().GetString("NGINX_HOST")
-	return nginxHost == "mythic_nginx" || nginxHost == "127.0.0.1"
+func isServiceInternal(service string) bool {
+	return manager.GetManager().IsServiceInternal(service)
 }
 
-func isPostgresInternal() bool {
-	return config.GetMythicEnv().GetString("POSTGRES_HOST") == "127.0.0.1" || config.GetMythicEnv().GetString("POSTGRES_HOST") == "mythic_postgres"
+func getExtraHosts() []string {
+	extraHosts := []string{}
+	for _, service := range config.MythicPossibleServices {
+		if isServiceInternal(service) {
+			extraHosts = append(extraHosts, fmt.Sprintf("%s:127.0.0.1", service))
+		}
+	}
+	return extraHosts
 }

--- a/Mythic_CLI/src/cmd/internal/serviceMetadata.go
+++ b/Mythic_CLI/src/cmd/internal/serviceMetadata.go
@@ -67,16 +67,19 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			pStruct["extra_hosts"] = []string{
+			extraHosts := []string{
 				"mythic_server:127.0.0.1",
 				"mythic_rabbitmq:127.0.0.1",
-				"mythic_nginx:127.0.0.1",
 				"mythic_react:127.0.0.1",
 				"mythic_documentation:127.0.0.1",
 				"mythic_graphql:127.0.0.1",
 				"mythic_jupyter:127.0.0.1",
 				"mythic_postgres:127.0.0.1",
 			}
+			if isNginxInternal() {
+				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
+			}
+			pStruct["extra_hosts"] = extraHosts
 			if mythicEnv.GetBool("postgres_bind_localhost_only") {
 				pStruct["command"] = "postgres -c \"max_connections=100\" -p ${POSTGRES_PORT} -c config_file=/etc/postgresql.conf -c \"listen_addresses=localhost\""
 			} else {
@@ -146,16 +149,19 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			pStruct["extra_hosts"] = []string{
+			extraHosts := []string{
 				"mythic_server:127.0.0.1",
 				"mythic_rabbitmq:127.0.0.1",
-				"mythic_nginx:127.0.0.1",
 				"mythic_react:127.0.0.1",
 				"mythic_documentation:127.0.0.1",
 				"mythic_graphql:127.0.0.1",
 				"mythic_jupyter:127.0.0.1",
 				"mythic_postgres:127.0.0.1",
 			}
+			if isNginxInternal() {
+				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
+			}
+			pStruct["extra_hosts"] = extraHosts
 			if mythicEnv.GetBool("documentation_bind_localhost_only") {
 				pStruct["environment"] = []string{
 					"DOCUMENTATION_PORT=${DOCUMENTATION_PORT}",
@@ -242,16 +248,19 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			pStruct["extra_hosts"] = []string{
+			extraHosts := []string{
 				"mythic_server:127.0.0.1",
 				"mythic_rabbitmq:127.0.0.1",
-				"mythic_nginx:127.0.0.1",
 				"mythic_react:127.0.0.1",
 				"mythic_documentation:127.0.0.1",
 				"mythic_graphql:127.0.0.1",
 				"mythic_jupyter:127.0.0.1",
 				"mythic_postgres:127.0.0.1",
 			}
+			if isNginxInternal() {
+				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
+			}
+			pStruct["extra_hosts"] = extraHosts
 			if mythicEnv.GetBool("hasura_bind_localhost_only") {
 				environment = append(environment, "HASURA_GRAPHQL_SERVER_HOST=127.0.0.1")
 			} else {
@@ -351,16 +360,19 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			pStruct["extra_hosts"] = []string{
+			extraHosts := []string{
 				"mythic_server:127.0.0.1",
 				"mythic_rabbitmq:127.0.0.1",
-				"mythic_nginx:127.0.0.1",
 				"mythic_react:127.0.0.1",
 				"mythic_documentation:127.0.0.1",
 				"mythic_graphql:127.0.0.1",
 				"mythic_jupyter:127.0.0.1",
 				"mythic_postgres:127.0.0.1",
 			}
+			if isNginxInternal() {
+				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
+			}
+			pStruct["extra_hosts"] = extraHosts
 			if mythicEnv.GetBool("nginx_bind_localhost_only") {
 				finalNginxEnv = append(finalNginxEnv, "NGINX_BIND_IPV4=127.0.0.1", "NGINX_BIND_IPV6=[::1]")
 			} else {
@@ -437,16 +449,19 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			pStruct["extra_hosts"] = []string{
+			extraHosts := []string{
 				"mythic_server:127.0.0.1",
 				"mythic_rabbitmq:127.0.0.1",
-				"mythic_nginx:127.0.0.1",
 				"mythic_react:127.0.0.1",
 				"mythic_documentation:127.0.0.1",
 				"mythic_graphql:127.0.0.1",
 				"mythic_jupyter:127.0.0.1",
 				"mythic_postgres:127.0.0.1",
 			}
+			if isNginxInternal() {
+				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
+			}
+			pStruct["extra_hosts"] = extraHosts
 			if mythicEnv.GetBool("rabbitmq_bind_localhost_only") {
 				environment = append(environment, "RABBITMQ_NODE_IP_ADDRESS=127.0.0.1", "RABBITMQ_NODE_PORT=${RABBITMQ_PORT}")
 			} else {
@@ -556,16 +571,19 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			pStruct["extra_hosts"] = []string{
+			extraHosts := []string{
 				"mythic_server:127.0.0.1",
 				"mythic_rabbitmq:127.0.0.1",
-				"mythic_nginx:127.0.0.1",
 				"mythic_react:127.0.0.1",
 				"mythic_documentation:127.0.0.1",
 				"mythic_graphql:127.0.0.1",
 				"mythic_jupyter:127.0.0.1",
 				"mythic_postgres:127.0.0.1",
 			}
+			if isNginxInternal() {
+				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
+			}
+			pStruct["extra_hosts"] = extraHosts
 			if mythicEnv.GetBool("mythic_react_bind_localhost_only") {
 				pStruct["environment"] = []string{
 					"MYTHIC_REACT_PORT=${MYTHIC_REACT_PORT}",
@@ -629,16 +647,19 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			pStruct["extra_hosts"] = []string{
+			extraHosts := []string{
 				"mythic_server:127.0.0.1",
 				"mythic_rabbitmq:127.0.0.1",
-				"mythic_nginx:127.0.0.1",
 				"mythic_react:127.0.0.1",
 				"mythic_documentation:127.0.0.1",
 				"mythic_graphql:127.0.0.1",
 				"mythic_jupyter:127.0.0.1",
 				"mythic_postgres:127.0.0.1",
 			}
+			if isNginxInternal() {
+				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
+			}
+			pStruct["extra_hosts"] = extraHosts
 			environment := []string{
 				"JUPYTER_TOKEN=${JUPYTER_TOKEN}",
 				"CHOWN_EXTRA=/projects",
@@ -753,16 +774,19 @@ func AddMythicService(service string, removeVolume bool) {
 		} else {
 			delete(pStruct, "ports")
 			pStruct["network_mode"] = "host"
-			pStruct["extra_hosts"] = []string{
+			extraHosts := []string{
 				"mythic_server:127.0.0.1",
 				"mythic_rabbitmq:127.0.0.1",
-				"mythic_nginx:127.0.0.1",
 				"mythic_react:127.0.0.1",
 				"mythic_documentation:127.0.0.1",
 				"mythic_graphql:127.0.0.1",
 				"mythic_jupyter:127.0.0.1",
 				"mythic_postgres:127.0.0.1",
 			}
+			if isNginxInternal() {
+				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
+			}
+			pStruct["extra_hosts"] = extraHosts
 		}
 
 		if _, ok := pStruct["environment"]; ok {
@@ -787,10 +811,12 @@ func AddMythicService(service string, removeVolume bool) {
 			}
 		}
 	case "mythic_sync":
-		pStruct["depends_on"] = map[string]map[string]string{
-			"mythic_nginx": {
-				"condition": "service_healthy",
-			},
+		if isNginxInternal() {
+			pStruct["depends_on"] = map[string]map[string]string{
+				"mythic_nginx": {"condition": "service_healthy"},
+			}
+		} else {
+			delete(pStruct, "depends_on")
 		}
 		absPath, err := filepath.Abs(filepath.Join(manager.GetManager().GetPathTo3rdPartyServicesOnDisk(), service))
 		if err != nil {
@@ -835,16 +861,19 @@ func AddMythicService(service string, removeVolume bool) {
 			delete(pStruct, "extra_hosts")
 		} else {
 			pStruct["network_mode"] = "host"
-			pStruct["extra_hosts"] = []string{
+			extraHosts := []string{
 				"mythic_server:127.0.0.1",
 				"mythic_rabbitmq:127.0.0.1",
-				"mythic_nginx:127.0.0.1",
 				"mythic_react:127.0.0.1",
 				"mythic_documentation:127.0.0.1",
 				"mythic_graphql:127.0.0.1",
 				"mythic_jupyter:127.0.0.1",
 				"mythic_postgres:127.0.0.1",
 			}
+			if isNginxInternal() {
+				extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
+			}
+			pStruct["extra_hosts"] = extraHosts
 		}
 
 	}
@@ -876,30 +905,33 @@ func Add3rdPartyService(service string, additionalConfigs map[string]interface{}
 		"args":    config.GetBuildArguments(),
 	}
 	existingConfig["network_mode"] = "host"
-	existingConfig["extra_hosts"] = []string{
+	extraHosts := []string{
 		"mythic_server:127.0.0.1",
 		"mythic_rabbitmq:127.0.0.1",
-		"mythic_nginx:127.0.0.1",
 		"mythic_react:127.0.0.1",
 		"mythic_documentation:127.0.0.1",
 		"mythic_graphql:127.0.0.1",
 		"mythic_jupyter:127.0.0.1",
 		"mythic_postgres:127.0.0.1",
 	}
-	existingConfig["depends_on"] = map[string]map[string]string{
-		"mythic_server": {
-			"condition": "service_healthy",
-		},
-		"mythic_rabbitmq": {
-			"condition": "service_healthy",
-		},
-		"mythic_nginx": {
-			"condition": "service_healthy",
-		},
-		"mythic_graphql": {
-			"condition": "service_healthy",
-		},
+
+	if isNginxInternal() {
+		extraHosts = append(extraHosts, "mythic_nginx:127.0.0.1")
 	}
+
+	existingConfig["extra_hosts"] = extraHosts
+
+	dependsOn := map[string]map[string]string{
+		"mythic_server":   {"condition": "service_healthy"},
+		"mythic_rabbitmq": {"condition": "service_healthy"},
+		"mythic_graphql":  {"condition": "service_healthy"},
+	}
+
+	if isNginxInternal() {
+		dependsOn["mythic_nginx"] = map[string]string{"condition": "service_healthy"}
+	}
+
+	existingConfig["depends_on"] = dependsOn
 	agentConfigs := config.GetConfigStrings([]string{fmt.Sprintf("%s_.*", service)})
 	agentUseBuildContextKey := fmt.Sprintf("%s_use_build_context", service)
 	agentRemoteImageKey := fmt.Sprintf("%s_remote_image", service)
@@ -1015,6 +1047,11 @@ func applyImageMirror(imageURL, mirror string) string {
 		}
 	}
 	return mirror + "/" + imageURL
+}
+
+func isNginxInternal() bool {
+	nginxHost := config.GetMythicEnv().GetString("NGINX_HOST")
+	return nginxHost == "mythic_nginx" || nginxHost == "127.0.0.1"
 }
 
 func isPostgresInternal() bool {

--- a/Mythic_CLI/src/cmd/internal/serviceMetadata.go
+++ b/Mythic_CLI/src/cmd/internal/serviceMetadata.go
@@ -185,14 +185,17 @@ func AddMythicService(service string, removeVolume bool) {
 			}
 		}
 	case "mythic_graphql":
-		pStruct["depends_on"] = map[string]map[string]string{
-			"mythic_postgres": {
-				"condition": "service_healthy",
-			},
+		dependsOn := map[string]map[string]string{
 			"mythic_server": {
 				"condition": "service_healthy",
 			},
 		}
+		if isPostgresInternal() {
+			dependsOn["mythic_postgres"] = map[string]string{
+				"condition": "service_healthy",
+			}
+		}
+		pStruct["depends_on"] = dependsOn
 		if mythicEnv.GetBool("hasura_use_build_context") {
 			pStruct["build"] = map[string]interface{}{
 				"context": "./hasura-docker",
@@ -208,8 +211,8 @@ func AddMythicService(service string, removeVolume bool) {
 			pStruct["mem_limit"] = mythicEnv.GetString("hasura_mem_limit")
 		}
 		environment := []string{
-			"HASURA_GRAPHQL_DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}",
-			"HASURA_GRAPHQL_METADATA_DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}",
+			"HASURA_GRAPHQL_DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=${POSTGRES_SSLMODE:-disable}",
+			"HASURA_GRAPHQL_METADATA_DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=${POSTGRES_SSLMODE:-disable}",
 			"HASURA_GRAPHQL_ENABLE_CONSOLE=true",
 			"HASURA_GRAPHQL_DEV_MODE=false",
 			"HASURA_GRAPHQL_ADMIN_SECRET=${HASURA_SECRET}",
@@ -469,17 +472,20 @@ func AddMythicService(service string, removeVolume bool) {
 			}
 		}
 	case "mythic_react":
-		pStruct["depends_on"] = map[string]map[string]string{
+		dependsOn := map[string]map[string]string{
 			"mythic_server": {
 				"condition": "service_healthy",
 			},
 			"mythic_graphql": {
 				"condition": "service_healthy",
 			},
-			"mythic_postgres": {
-				"condition": "service_healthy",
-			},
 		}
+		if isPostgresInternal() {
+			dependsOn["mythic_postgres"] = map[string]string{
+				"condition": "service_healthy",
+			}
+		}
+		pStruct["depends_on"] = dependsOn
 		if mythicEnv.GetBool("mythic_react_debug") {
 			pStruct["build"] = map[string]interface{}{
 				"context": "./MythicReactUI",
@@ -574,17 +580,20 @@ func AddMythicService(service string, removeVolume bool) {
 		}
 
 	case "mythic_jupyter":
-		pStruct["depends_on"] = map[string]map[string]string{
+		dependsOn := map[string]map[string]string{
 			"mythic_server": {
-				"condition": "service_healthy",
-			},
-			"mythic_postgres": {
 				"condition": "service_healthy",
 			},
 			"mythic_graphql": {
 				"condition": "service_healthy",
 			},
 		}
+		if isPostgresInternal() {
+			dependsOn["mythic_postgres"] = map[string]string{
+				"condition": "service_healthy",
+			}
+		}
+		pStruct["depends_on"] = dependsOn
 		if mythicEnv.GetBool("jupyter_use_build_context") {
 			pStruct["build"] = map[string]interface{}{
 				"context": "./jupyter-docker",
@@ -665,14 +674,17 @@ func AddMythicService(service string, removeVolume bool) {
 			}
 		}
 	case "mythic_server":
-		pStruct["depends_on"] = map[string]map[string]string{
-			"mythic_postgres": {
-				"condition": "service_healthy",
-			},
+		dependsOn := map[string]map[string]string{
 			"mythic_rabbitmq": {
 				"condition": "service_healthy",
 			},
 		}
+		if isPostgresInternal() {
+			dependsOn["mythic_postgres"] = map[string]string{
+				"condition": "service_healthy",
+			}
+		}
+		pStruct["depends_on"] = dependsOn
 		if mythicEnv.GetBool("mythic_server_use_build_context") {
 			pStruct["build"] = map[string]interface{}{
 				"context": "./mythic-docker",
@@ -710,6 +722,7 @@ func AddMythicService(service string, removeVolume bool) {
 			"POSTGRES_HOST=${POSTGRES_HOST}",
 			"POSTGRES_PORT=${POSTGRES_PORT}",
 			"POSTGRES_PASSWORD=${POSTGRES_PASSWORD}",
+			"POSTGRES_SSLMODE=${POSTGRES_SSLMODE}",
 			"RABBITMQ_HOST=${RABBITMQ_HOST}",
 			"RABBITMQ_PORT=${RABBITMQ_PORT}",
 			"RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD}",
@@ -1002,4 +1015,8 @@ func applyImageMirror(imageURL, mirror string) string {
 		}
 	}
 	return mirror + "/" + imageURL
+}
+
+func isPostgresInternal() bool {
+	return config.GetMythicEnv().GetString("POSTGRES_HOST") == "127.0.0.1" || config.GetMythicEnv().GetString("POSTGRES_HOST") == "mythic_postgres"
 }

--- a/Mythic_CLI/src/cmd/internal/utils.go
+++ b/Mythic_CLI/src/cmd/internal/utils.go
@@ -112,6 +112,9 @@ func updateNginxBlockLists() {
 	outputString += "deny all;"
 	if !config.GetMythicEnv().GetBool("nginx_use_volume") {
 		ipFilePath := filepath.Join(utils.GetCwdFromExe(), "nginx-docker", "config", "blockips.conf")
+		if err := os.MkdirAll(filepath.Dir(ipFilePath), 0755); err != nil {
+			log.Fatalf("[-] Failed to create nginx-docker/config directory for block list file: %v\n", err)
+		}
 		if err := os.WriteFile(ipFilePath, []byte(outputString), 0600); err != nil {
 			log.Fatalf("[-] Failed to write out block list file: %v\n", err)
 		}

--- a/Mythic_CLI/src/cmd/manager/dockerComposeManager.go
+++ b/Mythic_CLI/src/cmd/manager/dockerComposeManager.go
@@ -92,6 +92,18 @@ func (d *DockerComposeManager) IsServiceRunning(service string) bool {
 	return false
 }
 
+// IsServiceInternal checks if a service is configured to run locally in docker vs externally
+func (d *DockerComposeManager) IsServiceInternal(service string) bool {
+	if !utils.StringInSlice(service, config.MythicPossibleServices) {
+		return true
+	}
+	intendedServices, err := config.GetIntendedMythicServiceNames()
+	if err != nil {
+		return true
+	}
+	return utils.StringInSlice(service, intendedServices)
+}
+
 // DoesImageExist use Docker API to check existing images for the specified name
 func (d *DockerComposeManager) DoesImageExist(service string) bool {
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
@@ -624,9 +636,9 @@ func (d *DockerComposeManager) TestPorts(services []string) {
 	var removeServices []string
 	mythicEnv := config.GetMythicEnv()
 	for key, val := range portChecks {
-		// only check ports for services we're about to start
+		// only check ports for services we're about to start that are running locally
 		if utils.StringInSlice(val[1], services) {
-			if mythicEnv.GetString(key) == val[1] || mythicEnv.GetString(key) == "127.0.0.1" {
+			if d.IsServiceInternal(val[1]) {
 				addServices = append(addServices, val[1])
 				p, err := net.Listen("tcp", ":"+strconv.Itoa(mythicEnv.GetInt(val[0])))
 				if err != nil {

--- a/Mythic_CLI/src/cmd/manager/dockerComposeManager.go
+++ b/Mythic_CLI/src/cmd/manager/dockerComposeManager.go
@@ -1413,7 +1413,7 @@ func (d *DockerComposeManager) runDockerCompose(args []string) error {
 			return err
 		}
 		if processState.ExitCode() != 0 {
-			return err
+			return fmt.Errorf("docker-compose %v exited with code %d", args, processState.ExitCode())
 		}
 	}
 	return nil

--- a/Mythic_CLI/src/cmd/manager/managerInterface.go
+++ b/Mythic_CLI/src/cmd/manager/managerInterface.go
@@ -12,6 +12,8 @@ type CLIManager interface {
 	GetManagerName() string
 	// IsServiceRunning checks if a service by the specified name is currently running or not
 	IsServiceRunning(service string) bool
+	// IsServiceInternal checks if a service is configured to run locally in docker vs externally
+	IsServiceInternal(service string) bool
 	// CheckRequiredManagerVersion checks if the version of the management software installed is a valid version or not
 	CheckRequiredManagerVersion() bool
 	// GenerateRequiredConfig creates any necessary base configuration files needed by the manager, like a docker-compose.yml file

--- a/Mythic_CLI/src/cmd/start.go
+++ b/Mythic_CLI/src/cmd/start.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/MythicMeta/Mythic_CLI/cmd/config"
 	"github.com/MythicMeta/Mythic_CLI/cmd/internal"
 	"github.com/spf13/cobra"
@@ -31,6 +33,6 @@ func start(cmd *cobra.Command, args []string) {
 		keepVolume = !config.GetMythicEnv().GetBool("REBUILD_ON_START")
 	}
 	if err := internal.ServiceStart(args, localKeepVolume); err != nil {
-
+		log.Fatalf("[-] Failed to start Mythic: %v\n", err)
 	}
 }

--- a/mythic-docker/src/database/initialize.go
+++ b/mythic-docker/src/database/initialize.go
@@ -36,6 +36,11 @@ func Initialize() {
 			logging.LogInfo("Disconnecting from database and reconnecting to load new schema")
 			DB.Close()
 			DB = getNewDbConnection()
+			if utils.MythicConfig.PostgresDebug {
+				if _, err := DB.Exec("CREATE EXTENSION IF NOT EXISTS pg_stat_statements SCHEMA public;"); err != nil {
+					logging.LogWarning("Failed to create pg_stat_statements extension (requires superuser)", "error", err.Error())
+				}
+			}
 			// we need to initialize the admin user and operation
 			salt := uuid.NewString()
 			newUser := databaseStructs.Operator{
@@ -161,12 +166,13 @@ func checkDBConnection() {
 func getNewDbConnection() *sqlx.DB {
 	for {
 		logging.LogInfo("Attempting to connect to database...", "host", utils.MythicConfig.PostgresHost, "port", utils.MythicConfig.PostgresPort)
-		conn, err := sqlx.Connect("postgres", fmt.Sprintf("user='%s' password='%s' host='%s' port='%d' dbname='%s' sslmode=disable connect_timeout=10",
+		conn, err := sqlx.Connect("postgres", fmt.Sprintf("user='%s' password='%s' host='%s' port='%d' dbname='%s' sslmode=%s connect_timeout=10",
 			utils.MythicConfig.PostgresUser,
 			utils.MythicConfig.PostgresPassword,
 			utils.MythicConfig.PostgresHost,
 			utils.MythicConfig.PostgresPort,
-			utils.MythicConfig.PostgresDB),
+			utils.MythicConfig.PostgresDB,
+			utils.MythicConfig.PostgresSSLMode),
 		)
 		if err != nil {
 			logging.LogError(err, "Failed to connect to database", "host", utils.MythicConfig.PostgresHost, "port", utils.MythicConfig.PostgresPort)

--- a/mythic-docker/src/database/schema.go
+++ b/mythic-docker/src/database/schema.go
@@ -4847,8 +4847,6 @@ ALTER TABLE ONLY public.wrappedpayloadtypes
 ALTER TABLE ONLY public.wrappedpayloadtypes
     ADD CONSTRAINT wrappedpayloadtypes_wrapper_id_fkey FOREIGN KEY (wrapper_id) REFERENCES public.payloadtype(id) ON DELETE CASCADE;
 
-CREATE EXTENSION pg_stat_statements SCHEMA public;
-
 --
 -- PostgreSQL database dump complete
 --

--- a/mythic-docker/src/utils/config.go
+++ b/mythic-docker/src/utils/config.go
@@ -47,6 +47,8 @@ type Config struct {
 	PostgresDB       string
 	PostgresUser     string
 	PostgresPassword string
+	PostgresSSLMode  string
+	PostgresDebug    bool
 
 	// jwt configuration
 	JWTSecret []byte
@@ -78,6 +80,8 @@ func Initialize() {
 	mythicEnv.SetDefault("postgres_db", "mythic_db")
 	mythicEnv.SetDefault("postgres_user", "mythic_user")
 	mythicEnv.SetDefault("postgres_password", "")
+	mythicEnv.SetDefault("postgres_sslmode", "disable")
+	mythicEnv.SetDefault("postgres_debug", false)
 	// rabbitmq configuration
 	mythicEnv.SetDefault("rabbitmq_host", "mythic_rabbitmq")
 	mythicEnv.SetDefault("rabbitmq_port", 5672)
@@ -180,6 +184,8 @@ func setConfigFromEnv(mythicEnv *viper.Viper) {
 	MythicConfig.PostgresDB = mythicEnv.GetString("postgres_db")
 	MythicConfig.PostgresUser = mythicEnv.GetString("postgres_user")
 	MythicConfig.PostgresPassword = mythicEnv.GetString("postgres_password")
+	MythicConfig.PostgresSSLMode = mythicEnv.GetString("postgres_sslmode")
+	MythicConfig.PostgresDebug = mythicEnv.GetBool("postgres_debug")
 	// rabbitmq configuration
 	MythicConfig.RabbitmqHost = mythicEnv.GetString("rabbitmq_host")
 	MythicConfig.RabbitmqPort = mythicEnv.GetUint("rabbitmq_port")


### PR DESCRIPTION
Adds generalized support for running Mythic services externally (e.g., PostgreSQL, Nginx, RabbitMQ, Hasura, etc.) without breaking `docker-compose` generation, container networking, or port validation. Previously, running services externally required one-off workarounds or would fail because the CLI still injected external services into container `extra_hosts`, generated empty `depends_on` blocks, or failed local port collision tests. 

This PR unifies external service resolution through a manager capability (`IsServiceInternal`), generalizes dependency graphs and `extra_hosts` mappings, adds database/SSL improvements, and gates service-specific housekeeping.

## Key Changes

### 1. Unified External Service Resolution (`CLIManager`)
- Added `IsServiceInternal(service string) bool` to `CLIManager` and implemented it on `DockerComposeManager`.
- Checks against `config.GetIntendedMythicServiceNames()` as the single source of truth determining whether a service is expected to run locally as a Docker container or externally.
- Gated `TestPorts` in `dockerComposeManager.go` with `d.IsServiceInternal(...)` to prevent false-positive port collision errors when services run on external hosts.

### 2. Generalized Compose Metadata & Dependency Graph (`serviceMetadata.go`)
- **Dynamic `depends_on` Resolution**: Evaluates upstream dependencies across all services (`mythic_graphql`, `mythic_nginx`, `mythic_react`, `mythic_jupyter`, `mythic_server`, `mythic_sync`, and installed 3rd-party services) with `isServiceInternal(...)`. If all dependencies for a container are external, the `depends_on` block is pruned rather than leaving an empty map.
- **Dynamic `extra_hosts` Resolution**: Replaced repetitive, hardcoded host mappings with `getExtraHosts()`, dynamically including `127.0.0.1` mappings only for services running internally. External services are omitted to prevent incorrect localhost loopback routing.
- **Direct Service Checks**: Removed legacy service-specific helpers (`isNginxInternal`, `isPostgresInternal`) in favor of direct calls to `isServiceInternal(...)`.

### 3. PostgreSQL & Database Improvements
- **Configurable SSL Mode**: Added support for `POSTGRES_SSLMODE` across the CLI configuration (`.env`), Hasura connection strings, and the `mythic_server` database initialization.
- **Superuser Bypass**: Made `pg_stat_statements` extension creation optional during schema initialization, gated behind `POSTGRES_DEBUG` to support external/managed databases (e.g., AWS RDS, GCP Cloud SQL) where superuser privileges are not granted.

### 4. Nginx & CLI Housekeeping
- **Housekeeping Gating**: In `serviceExecution.go`, gated `updateNginxBlockLists()` and `generateCerts()` behind `isServiceInternal("mythic_nginx")` so local certificate and blocklist generation only runs when Nginx is hosted locally.
- **Config Dir Creation**: Added `os.MkdirAll` before writing `blockips.conf` to avoid fatal errors when `nginx-docker/config` does not exist on a fresh clone.

## Verification

- **Build**: `mythic-cli` compiles cleanly with zero errors (`go build -v .`).
- **Tests**: Verified CLI package tests (`go test -vet=off ./...`) and `mythic_server` test suites (`crypto`, `eventing`).
- **Compose Generation**: Verified that running with external PostgreSQL or Nginx omits external hosts from `extra_hosts`, prunes empty `depends_on`, and does not trigger local port test failures.

## Supercedes

This PR Supersedes and replaces: 
- https://github.com/its-a-feature/Mythic/pull/591
- https://github.com/its-a-feature/Mythic/pull/592